### PR TITLE
Add offchain reindex parameter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,6 @@ test-programs
 # Rust build dirs
 /das_api/target
 /migration/target
+/tests/*/target
+/*/target
 /target

--- a/digital_asset_types/src/dao/generated/asset_data.rs
+++ b/digital_asset_types/src/dao/generated/asset_data.rs
@@ -23,6 +23,7 @@ pub struct Model {
     pub metadata_mutability: Mutability,
     pub metadata: Json,
     pub slot_updated: i64,
+    pub reindex: Option<bool>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
@@ -34,6 +35,7 @@ pub enum Column {
     MetadataMutability,
     Metadata,
     SlotUpdated,
+    Reindex,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DerivePrimaryKey)]
@@ -64,6 +66,7 @@ impl ColumnTrait for Column {
             Self::MetadataMutability => Mutability::db_type(),
             Self::Metadata => ColumnType::JsonBinary.def(),
             Self::SlotUpdated => ColumnType::BigInteger.def(),
+            Self::Reindex => ColumnType::Boolean.def(),
         }
     }
 }

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -16,6 +16,7 @@ mod m20230203_205959_improve_upsert_perf;
 mod m20230224_093722_performance_improvements;
 mod m20230310_162227_add_indexes_to_bg;
 mod m20230317_121944_remove_indexes_for_perf;
+mod m20230508_142103_add_offchain_reindex;
 
 pub struct Migrator;
 
@@ -39,6 +40,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20230224_093722_performance_improvements::Migration),
             Box::new(m20230310_162227_add_indexes_to_bg::Migration),
             Box::new(m20230317_121944_remove_indexes_for_perf::Migration),
+            Box::new(m20230508_142103_add_offchain_reindex::Migration),
         ]
     }
 }

--- a/migration/src/m20230508_142103_add_offchain_reindex.rs
+++ b/migration/src/m20230508_142103_add_offchain_reindex.rs
@@ -9,7 +9,7 @@ impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
           .alter_table(
-            seq_query::Table::alter()
+            sea_query::Table::alter()
               .table(asset_data::Entity)
               .add_column(
                 ColumnDef::new(Alias::new("reindex"))
@@ -17,7 +17,7 @@ impl MigrationTrait for Migration {
               )
               .to_owned(),
             )
-            .await?
+            .await?;
         Ok(())
     }
 

--- a/migration/src/m20230508_142103_add_offchain_reindex.rs
+++ b/migration/src/m20230508_142103_add_offchain_reindex.rs
@@ -1,0 +1,35 @@
+use digital_asset_types::dao::asset_data;
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+          .alter_table(
+            seq_query::Table::alter()
+              .table(asset_data::Entity)
+              .add_column(
+                ColumnDef::new(Alias::new("reindex"))
+                  .boolean()
+              )
+              .to_owned(),
+            )
+            .await?
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+      manager
+        .alter_table(
+          sea_query::Table::alter()
+            .table(asset_data::Entity)
+            .drop_column(Alias::new("reindex"))
+            .to_owned(),
+          )
+          .await?;
+      Ok(())
+    }
+}

--- a/migration/src/m20230508_142103_add_offchain_reindex.rs
+++ b/migration/src/m20230508_142103_add_offchain_reindex.rs
@@ -14,6 +14,7 @@ impl MigrationTrait for Migration {
               .add_column(
                 ColumnDef::new(Alias::new("reindex"))
                   .boolean()
+                  .default(false)
               )
               .to_owned(),
             )

--- a/nft_ingester/src/program_transformers/bubblegum/mint_v1.rs
+++ b/nft_ingester/src/program_transformers/bubblegum/mint_v1.rs
@@ -92,6 +92,7 @@ where
                     metadata: Set(JsonValue::String("processing".to_string())),
                     metadata_mutability: Set(Mutability::Mutable),
                     slot_updated: Set(slot_i),
+                    reindex: Set(Some(true)),
                 };
 
                 let mut query = asset_data::Entity::insert(data)
@@ -101,9 +102,9 @@ where
                                 asset_data::Column::ChainDataMutability,
                                 asset_data::Column::ChainData,
                                 asset_data::Column::MetadataUrl,
-                                asset_data::Column::Metadata,
                                 asset_data::Column::MetadataMutability,
                                 asset_data::Column::SlotUpdated,
+                                asset_data::Column::Reindex,
                             ])
                             .to_owned(),
                     )

--- a/nft_ingester/src/program_transformers/token_metadata/v1_asset.rs
+++ b/nft_ingester/src/program_transformers/token_metadata/v1_asset.rs
@@ -147,6 +147,7 @@ pub async fn save_v1_asset<T: ConnectionTrait + TransactionTrait>(
         metadata: Set(JsonValue::String("processing".to_string())),
         metadata_mutability: Set(Mutability::Mutable),
         slot_updated: Set(slot_i),
+        reindex: Set(Some(true)),
         id: Set(id.to_vec()),
     };
     let txn = conn.begin().await?;
@@ -157,9 +158,9 @@ pub async fn save_v1_asset<T: ConnectionTrait + TransactionTrait>(
                     asset_data::Column::ChainDataMutability,
                     asset_data::Column::ChainData,
                     asset_data::Column::MetadataUrl,
-                    asset_data::Column::Metadata,
                     asset_data::Column::MetadataMutability,
                     asset_data::Column::SlotUpdated,
+                    asset_data::Column::Reindex,
                 ])
                 .to_owned(),
         )

--- a/nft_ingester/src/tasks/common/mod.rs
+++ b/nft_ingester/src/tasks/common/mod.rs
@@ -109,6 +109,7 @@ impl BgTask for DownloadMetadataTask {
         let model = asset_data::ActiveModel {
             id: Unchanged(download_metadata.asset_data_id.clone()),
             metadata: Set(body),
+            reindex: Set(Some(false)),
             ..Default::default()
         };
         debug!(

--- a/tests/bgtask_creator/src/main.rs
+++ b/tests/bgtask_creator/src/main.rs
@@ -129,8 +129,9 @@ pub async fn main() {
     // Find all the assets with missing metadata
     let mut asset_data_missing = asset_data::Entity::find()
         .filter(
-            Condition::all()
-                .add(asset_data::Column::Metadata.eq(JsonValue::String("processing".to_string()))),
+            Condition::any()
+                .add(asset_data::Column::Metadata.eq(JsonValue::String("processing".to_string())))
+                .add(asset_data::Column::Reindex.eq(Some(true))),
         )
         .order_by(asset_data::Column::Id, Order::Asc)
         .paginate(&conn, *batch_size)


### PR DESCRIPTION
This adds an offchain reindexer parameter that allows to trigger reindexing  without updating the stored metadata json.