### PR TITLE
add check-tree-leaf to tree-status

### DIFF
--- a/digital_asset_types/tests/common.rs
+++ b/digital_asset_types/tests/common.rs
@@ -82,6 +82,7 @@ pub fn create_asset_data(
             metadata_mutability: Mutability::Mutable,
             metadata: JsonValue::String("processing".to_string()),
             slot_updated: 0,
+            reindex: None,
         },
     )
 }

--- a/digital_asset_types/tests/json_parsing.rs
+++ b/digital_asset_types/tests/json_parsing.rs
@@ -28,6 +28,7 @@ pub async fn test_json(uri: String) -> Content {
         metadata_mutability: Mutability::Mutable,
         metadata: body,
         slot_updated: 0,
+        reindex: None,
     };
 
     v1_content_from_json(&asset_data).unwrap()

--- a/tests/tree-status/src/main.rs
+++ b/tests/tree-status/src/main.rs
@@ -3,7 +3,7 @@ use {
     anyhow::Context,
     clap::{arg, Parser, Subcommand},
     digital_asset_types::dao::cl_items,
-    futures::future::{try_join, try_join_all, TryFutureExt},
+    futures::future::{try_join, try_join_all, BoxFuture, FutureExt, TryFutureExt},
     sea_orm::{
         sea_query::Expr, ColumnTrait, ConnectionTrait, DatabaseConnection, DbBackend, DbErr,
         EntityTrait, FromQueryResult, QueryFilter, QuerySelect, QueryTrait, SqlxPostgresConnector,
@@ -91,26 +91,60 @@ struct Args {
     action: Action,
 }
 
+impl Args {
+    async fn get_pg_conn(&self) -> anyhow::Result<DatabaseConnection> {
+        match &self.action {
+            Action::CheckTree { pg_url, .. }
+            | Action::CheckTrees { pg_url, .. }
+            | Action::CheckTreeLeafs { pg_url, .. }
+            | Action::CheckTreesLeafs { pg_url, .. } => {
+                let options: PgConnectOptions = pg_url.parse().unwrap();
+
+                // Create postgres pool
+                let pool = PgPoolOptions::new()
+                    .min_connections(2)
+                    .max_connections(10)
+                    .connect_with(options)
+                    .await?;
+
+                // Create new postgres connection
+                Ok(SqlxPostgresConnector::from_sqlx_postgres_pool(pool))
+            }
+            Action::ShowTree { .. } | Action::ShowTrees { .. } => {
+                anyhow::bail!("show-tree and show-tress do not have connection to database")
+            }
+        }
+    }
+}
+
 #[derive(Subcommand, Clone)]
 enum Action {
-    /// Checks a single merkle tree to check if it;s fully indexed
+    /// Checks a single merkle tree to check if it's fully indexed
     CheckTree {
         #[arg(short, long)]
         pg_url: String,
-
-        #[arg(short, long, help = "Takes a single pubkey as a parameter to check")]
+        #[arg(short, long, help = "Tree pubkey")]
         tree: String,
     },
     /// Checks a list of merkle trees to check if they're fully indexed
     CheckTrees {
         #[arg(short, long)]
         pg_url: String,
-
-        #[arg(
-            short,
-            long,
-            help = "Takes a path to a file with pubkeys as a parameter to check"
-        )]
+        #[arg(short, long, help = "Path to file with trees pubkeys")]
+        file: String,
+    },
+    /// Checks leafs from a single merkle tree with assets from database
+    CheckTreeLeafs {
+        #[arg(short, long)]
+        pg_url: String,
+        #[arg(short, long, help = "Tree pubkey")]
+        tree: String,
+    },
+    /// Checks leafs from merkle tree from a file with assets from database
+    CheckTreesLeafs {
+        #[arg(short, long)]
+        pg_url: String,
+        #[arg(short, long, help = "Path to file with trees pubkeys")]
         file: String,
     },
     /// Show a tree
@@ -134,18 +168,20 @@ async fn main() -> anyhow::Result<()> {
 
     // Set up RPC interface
     let pubkeys_str = match &args.action {
-        Action::CheckTree { tree, .. } | Action::ShowTree { tree } => vec![tree.to_string()],
-        Action::CheckTrees { file, .. } | Action::ShowTrees { file } => {
-            tokio::fs::read_to_string(&file)
-                .await
-                .with_context(|| format!("failed to read file with keys: {:?}", file))?
-                .split('\n')
-                .filter_map(|x| {
-                    let x = x.trim();
-                    (!x.is_empty()).then(|| x.to_string())
-                })
-                .collect()
-        }
+        Action::CheckTree { tree, .. }
+        | Action::CheckTreeLeafs { tree, .. }
+        | Action::ShowTree { tree } => vec![tree.to_string()],
+        Action::CheckTrees { file, .. }
+        | Action::CheckTreesLeafs { file, .. }
+        | Action::ShowTrees { file } => tokio::fs::read_to_string(&file)
+            .await
+            .with_context(|| format!("failed to read file with keys: {:?}", file))?
+            .split('\n')
+            .filter_map(|x| {
+                let x = x.trim();
+                (!x.is_empty()).then(|| x.to_string())
+            })
+            .collect(),
     };
 
     let mut pubkeys: Vec<Pubkey> = vec![];
@@ -158,27 +194,23 @@ async fn main() -> anyhow::Result<()> {
     }
 
     match args.action {
-        Action::CheckTree { pg_url, .. } | Action::CheckTrees { pg_url, .. } => {
-            let client = RpcClient::new(args.rpc);
-
-            // Set up db connection
-            let url = pg_url;
-            let options: PgConnectOptions = url.parse().unwrap();
-
-            // Create postgres pool
-            let pool = PgPoolOptions::new()
-                .min_connections(2)
-                .max_connections(10)
-                .connect_with(options)
-                .await
-                .unwrap();
-
-            // Create new postgres connection
-            let conn = SqlxPostgresConnector::from_sqlx_postgres_pool(pool.clone());
-
+        Action::CheckTree { .. } | Action::CheckTrees { .. } => {
+            let client = RpcClient::new(args.rpc.clone());
+            let conn = args.get_pg_conn().await?;
             for pubkey in pubkeys {
                 println!("checking tree {pubkey}");
                 if let Err(error) = check_tree(pubkey, &client, &conn).await {
+                    eprintln!("{:?}", error);
+                }
+            }
+        }
+        Action::CheckTreeLeafs { .. } | Action::CheckTreesLeafs { .. } => {
+            let conn = args.get_pg_conn().await?;
+            for pubkey in pubkeys {
+                println!("checking tree leafs {pubkey}");
+                if let Err(error) =
+                    check_tree_leafs(pubkey, &args.rpc, concurrency, args.max_retries, &conn).await
+                {
                     eprintln!("{:?}", error);
                 }
             }
@@ -196,6 +228,35 @@ async fn main() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+async fn check_tree_leafs(
+    pubkey: Pubkey,
+    client_url: &str,
+    concurrency: NonZeroUsize,
+    max_retries: u8,
+    conn: &DatabaseConnection,
+) -> anyhow::Result<()> {
+    let (fetch_fut, mut leafs_rx) = read_tree_start(pubkey, client_url, concurrency, max_retries);
+    try_join(fetch_fut, async move {
+        // collect max seq per leaf from transactions
+        let mut leafs = HashMap::new();
+        while let Some((_id, _signature, Some(vec))) = leafs_rx.recv().await {
+            for (seq, maybe_leaf) in vec {
+                if let Some(leaf) = maybe_leaf {
+                    let entry = leafs.entry(leaf).or_insert(seq);
+                    if *entry < seq {
+                        *entry = seq;
+                    }
+                }
+            }
+        }
+
+        //
+        Ok(())
+    })
+    .await
+    .map(|_| ())
 }
 
 async fn check_tree(
@@ -293,9 +354,21 @@ async fn get_missing_seq(
     conn: &DatabaseConnection,
 ) -> Result<Vec<MissingSeq>, DbErr> {
     let query = Statement::from_string(
-            DbBackend::Postgres,
-            format!("SELECT s.seq AS missing_seq FROM generate_series(1::bigint, {}::bigint) s(seq) WHERE NOT EXISTS (SELECT 1 FROM cl_items WHERE seq = s.seq AND tree='\\x{}')", max_seq, hex::encode(tree.as_ref()))
-        );
+        DbBackend::Postgres,
+        format!(
+            "
+SELECT
+    s.seq AS missing_seq
+FROM
+    generate_series(1::bigint, {}::bigint) s(seq)
+WHERE
+    NOT EXISTS (
+        SELECT 1 FROM cl_items WHERE seq = s.seq AND tree='\\x{}'
+    )",
+            max_seq,
+            hex::encode(tree.as_ref())
+        ),
+    );
 
     Ok(conn
         .query_all(query)
@@ -312,42 +385,6 @@ async fn read_tree(
     concurrency: NonZeroUsize,
     max_retries: u8,
 ) -> anyhow::Result<()> {
-    let sig_id = Arc::new(AtomicUsize::new(0));
-    let rx_sig = Arc::new(Mutex::new(find_signatures(
-        pubkey,
-        RpcClient::new(client_url.to_owned()),
-        2_000,
-    )));
-
-    let (print_tx, mut print_rx) = mpsc::unbounded_channel();
-    let print_tx = Arc::new(print_tx);
-
-    let fetch_futs = (0..concurrency.get())
-        .map(|_| {
-            let sig_id = Arc::clone(&sig_id);
-            let rx_sig = Arc::clone(&rx_sig);
-            let client = RpcClient::new(client_url.to_owned());
-            let print_tx = Arc::clone(&print_tx);
-            async move {
-                loop {
-                    let mut lock = rx_sig.lock().await;
-                    let maybe_msg = lock.recv().await;
-                    let id = sig_id.fetch_add(1, Ordering::SeqCst);
-                    drop(lock);
-                    match maybe_msg {
-                        Some(maybe_sig) => {
-                            let signature = maybe_sig?;
-                            let mut map = process_txn(signature, &client, max_retries).await?;
-                            let _ = print_tx.send((id, signature, map.remove(&pubkey)));
-                        }
-                        None => return Ok::<(), anyhow::Error>(()),
-                    }
-                }
-            }
-        })
-        .collect::<Vec<_>>();
-    drop(print_tx);
-
     fn print_seqs(id: usize, sig: Signature, seqs: Option<Vec<(u64, Option<i64>)>>) {
         for (seq, leaf_idx) in seqs.unwrap_or_default() {
             let leaf_idx = leaf_idx.map(|v| v.to_string()).unwrap_or_default();
@@ -355,7 +392,8 @@ async fn read_tree(
         }
     }
 
-    try_join(try_join_all(fetch_futs).map_ok(|_| ()), async move {
+    let (fetch_fut, mut print_rx) = read_tree_start(pubkey, client_url, concurrency, max_retries);
+    try_join(fetch_fut, async move {
         let mut next_id = 0;
         let mut map = HashMap::new();
 
@@ -378,6 +416,54 @@ async fn read_tree(
     })
     .await
     .map(|_| ())
+}
+
+fn read_tree_start(
+    pubkey: Pubkey,
+    client_url: &str,
+    concurrency: NonZeroUsize,
+    max_retries: u8,
+) -> (
+    BoxFuture<'static, anyhow::Result<()>>,
+    mpsc::UnboundedReceiver<(usize, Signature, Option<Vec<(u64, Option<i64>)>>)>,
+) {
+    let sig_id = Arc::new(AtomicUsize::new(0));
+    let rx_sig = Arc::new(Mutex::new(find_signatures(
+        pubkey,
+        RpcClient::new(client_url.to_owned()),
+        2_000,
+    )));
+
+    let (tx, rx) = mpsc::unbounded_channel();
+    let tx = Arc::new(tx);
+
+    let fetch_futs = (0..concurrency.get())
+        .map(|_| {
+            let sig_id = Arc::clone(&sig_id);
+            let rx_sig = Arc::clone(&rx_sig);
+            let client = RpcClient::new(client_url.to_owned());
+            let tx = Arc::clone(&tx);
+            async move {
+                loop {
+                    let mut lock = rx_sig.lock().await;
+                    let maybe_msg = lock.recv().await;
+                    let id = sig_id.fetch_add(1, Ordering::SeqCst);
+                    drop(lock);
+                    match maybe_msg {
+                        Some(maybe_sig) => {
+                            let signature = maybe_sig?;
+                            let mut map = process_txn(signature, &client, max_retries).await?;
+                            let _ = tx.send((id, signature, map.remove(&pubkey)));
+                        }
+                        None => return Ok::<(), anyhow::Error>(()),
+                    }
+                }
+            }
+        })
+        .collect::<Vec<_>>();
+    drop(tx);
+
+    (try_join_all(fetch_futs).map_ok(|_| ()).boxed(), rx)
 }
 
 // Process and individual transaction, fetching it and reading out the sequence numbers


### PR DESCRIPTION
Compare maximum seq number per each leaf with assets table in database

example:
```
     Running `target/debug/tree-status --rpc {RPC} check-tree-leafs -p {POSTGRES} -t 8wKvdzBu2kEG5T3maJBX8m2gLs4XFavXzCKiZcGVeS8T`
checking tree leafs 8wKvdzBu2kEG5T3maJBX8m2gLs4XFavXzCKiZcGVeS8T
b6f35ce4a304f88a74966628420d8a965a19c7e02af9f350dd8fe16c91d4bc70 247: not found in db, seq 248
0000000000000000000000000000000000000000000000000000000000000000 0: not found in db, seq 0
d6f9e2cea59a9a3a1927a734bc28be0bfacc725fe36faac712aeb3a0ab2db068 525: not found in db, seq 526
```