### PR TITLE
tests tools: support custom header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,7 +14,7 @@ dependencies = [
 
 [[package]]
 name = "acc_forwarder"
-version = "0.0.1"
+version = "0.7.12"
 dependencies = [
  "anyhow",
  "bs58 0.4.0",
@@ -618,7 +618,7 @@ checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bgtask_creator"
-version = "0.1.0"
+version = "0.7.12"
 dependencies = [
  "anyhow",
  "clap 4.2.7",
@@ -1460,7 +1460,7 @@ dependencies = [
 
 [[package]]
 name = "digital_asset_types"
-version = "0.6.8"
+version = "0.7.12"
 dependencies = [
  "blockbuster",
  "bs58 0.4.0",
@@ -2524,7 +2524,7 @@ checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
 
 [[package]]
 name = "load_generation"
-version = "0.1.0"
+version = "0.7.12"
 dependencies = [
  "fake",
  "mpl-token-metadata",
@@ -2621,7 +2621,7 @@ dependencies = [
 
 [[package]]
 name = "metaplex-rpc-proxy"
-version = "0.6.8"
+version = "0.7.12"
 dependencies = [
  "lazy_static",
  "log",
@@ -2812,7 +2812,7 @@ dependencies = [
 
 [[package]]
 name = "nft_ingester"
-version = "0.7.1"
+version = "0.7.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5940,7 +5940,7 @@ dependencies = [
 
 [[package]]
 name = "tree-status"
-version = "0.1.0"
+version = "0.7.12"
 dependencies = [
  "anchor-client",
  "anyhow",
@@ -6007,7 +6007,7 @@ dependencies = [
 
 [[package]]
 name = "txn_forwarder"
-version = "0.6.9"
+version = "0.7.12"
 dependencies = [
  "anyhow",
  "clap 4.2.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4650,8 +4650,7 @@ dependencies = [
 [[package]]
 name = "solana-account-decoder"
 version = "1.14.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b34f8342ffa6180a3368e51b933abf0ef09dc8333b4a41b76bb3085e530608c"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-client-custom-header#afc0ab648774a30f1a6d4100b9e2c53aae6079cf"
 dependencies = [
  "Inflector",
  "base64 0.13.1",
@@ -4675,8 +4674,7 @@ dependencies = [
 [[package]]
 name = "solana-address-lookup-table-program"
 version = "1.14.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15112ecf013f15e53d5a50fd413f93b47343a5b911f96ee143ffab2f497eff66"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-client-custom-header#afc0ab648774a30f1a6d4100b9e2c53aae6079cf"
 dependencies = [
  "bincode",
  "bytemuck",
@@ -4696,8 +4694,7 @@ dependencies = [
 [[package]]
 name = "solana-clap-utils"
 version = "1.14.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223a78a2945a50fc49ce4ec58e079aa6c2f33fdf29387bffab224a9f51908714"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-client-custom-header#afc0ab648774a30f1a6d4100b9e2c53aae6079cf"
 dependencies = [
  "chrono",
  "clap 2.34.0",
@@ -4714,8 +4711,7 @@ dependencies = [
 [[package]]
 name = "solana-cli-config"
 version = "1.14.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "917eb35225a067b87ab797f454e553aea34dcc4ed495b1e9413a5a7de35194a0"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-client-custom-header#afc0ab648774a30f1a6d4100b9e2c53aae6079cf"
 dependencies = [
  "dirs-next",
  "lazy_static",
@@ -4730,8 +4726,7 @@ dependencies = [
 [[package]]
 name = "solana-client"
 version = "1.14.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a396056359554ef0882be7f9cf4eb6942df761055cd8f7771a04bcd78e40fe"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-client-custom-header#afc0ab648774a30f1a6d4100b9e2c53aae6079cf"
 dependencies = [
  "async-mutex",
  "async-trait",
@@ -4784,8 +4779,7 @@ dependencies = [
 [[package]]
 name = "solana-config-program"
 version = "1.14.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388bc028b037da5752bd2e6910afe8007232ddc58eb2c7a2523f1c6d818abe90"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-client-custom-header#afc0ab648774a30f1a6d4100b9e2c53aae6079cf"
 dependencies = [
  "bincode",
  "chrono",
@@ -4798,8 +4792,7 @@ dependencies = [
 [[package]]
 name = "solana-faucet"
 version = "1.14.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91a52f211164c9403c1ea11318b388d8d4bcfe3a886f7f70f695ade5409e359f"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-client-custom-header#afc0ab648774a30f1a6d4100b9e2c53aae6079cf"
 dependencies = [
  "bincode",
  "byteorder",
@@ -4822,8 +4815,7 @@ dependencies = [
 [[package]]
 name = "solana-frozen-abi"
 version = "1.14.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f651fd3d06d9aa6c66d2ceb7230278ddad59403dc1cc4abf82a69970dc6f631d"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-client-custom-header#afc0ab648774a30f1a6d4100b9e2c53aae6079cf"
 dependencies = [
  "ahash 0.7.6",
  "blake3",
@@ -4856,8 +4848,7 @@ dependencies = [
 [[package]]
 name = "solana-frozen-abi-macro"
 version = "1.14.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301bb4bd66f592d4b799db0fb0ed1ae9fc7a8453476961faef1223127091574b"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-client-custom-header#afc0ab648774a30f1a6d4100b9e2c53aae6079cf"
 dependencies = [
  "proc-macro2 1.0.56",
  "quote 1.0.26",
@@ -4883,8 +4874,7 @@ dependencies = [
 [[package]]
 name = "solana-logger"
 version = "1.14.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305cf85e48a7660df7a483762dcf7989d4b3f6e3de2153f2f9f98ba3785a0bd6"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-client-custom-header#afc0ab648774a30f1a6d4100b9e2c53aae6079cf"
 dependencies = [
  "env_logger 0.9.3",
  "lazy_static",
@@ -4894,8 +4884,7 @@ dependencies = [
 [[package]]
 name = "solana-measure"
 version = "1.14.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a19c00ebaf498911266b63bc55f78916bf3c6fe236316af8144e024df14c6d7"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-client-custom-header#afc0ab648774a30f1a6d4100b9e2c53aae6079cf"
 dependencies = [
  "log",
  "solana-sdk",
@@ -4904,8 +4893,7 @@ dependencies = [
 [[package]]
 name = "solana-metrics"
 version = "1.14.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2dbc83864877ece6f686ba04e1230fc933916ca21bbf3aff9aac393918a3c63"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-client-custom-header#afc0ab648774a30f1a6d4100b9e2c53aae6079cf"
 dependencies = [
  "crossbeam-channel",
  "gethostname",
@@ -4918,8 +4906,7 @@ dependencies = [
 [[package]]
 name = "solana-net-utils"
 version = "1.14.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daaace80b5fe18adf86447cbe53f4a8424fa1be5d6f49ed816efd32769221c84"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-client-custom-header#afc0ab648774a30f1a6d4100b9e2c53aae6079cf"
 dependencies = [
  "bincode",
  "clap 3.2.25",
@@ -4940,8 +4927,7 @@ dependencies = [
 [[package]]
 name = "solana-perf"
 version = "1.14.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3259b43ea1f93f825176bf1310ba7ace17541e0aae4c9167986a92d903ef92eb"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-client-custom-header#afc0ab648774a30f1a6d4100b9e2c53aae6079cf"
 dependencies = [
  "ahash 0.7.6",
  "bincode",
@@ -4967,8 +4953,7 @@ dependencies = [
 [[package]]
 name = "solana-program"
 version = "1.14.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a52d34820e44c56a23ef540a9c996873885c4834e7e36bc5901990c675603c"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-client-custom-header#afc0ab648774a30f1a6d4100b9e2c53aae6079cf"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -5016,8 +5001,7 @@ dependencies = [
 [[package]]
 name = "solana-program-runtime"
 version = "1.14.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bc5a5da86d34d458ce0fd67992f1a82b15b775b7c38e791e8a17ec3a08803ac"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-client-custom-header#afc0ab648774a30f1a6d4100b9e2c53aae6079cf"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -5043,8 +5027,7 @@ dependencies = [
 [[package]]
 name = "solana-rayon-threadlimit"
 version = "1.14.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17ca466115ea5d65863c8ce717efde714308dd60931244ea42ba394fac471a7c"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-client-custom-header#afc0ab648774a30f1a6d4100b9e2c53aae6079cf"
 dependencies = [
  "lazy_static",
  "num_cpus",
@@ -5053,8 +5036,7 @@ dependencies = [
 [[package]]
 name = "solana-remote-wallet"
 version = "1.14.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0bdffc62c46598a541fab68355e313b5bae3429bcd4910761f4f6f63b849f5"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-client-custom-header#afc0ab648774a30f1a6d4100b9e2c53aae6079cf"
 dependencies = [
  "console",
  "dialoguer",
@@ -5072,8 +5054,7 @@ dependencies = [
 [[package]]
 name = "solana-sdk"
 version = "1.14.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ac3ab8b970c3e4c07d0c2b184a0be449075e933c81f0e27cd9fcab2b122020"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-client-custom-header#afc0ab648774a30f1a6d4100b9e2c53aae6079cf"
 dependencies = [
  "assert_matches",
  "base64 0.13.1",
@@ -5123,8 +5104,7 @@ dependencies = [
 [[package]]
 name = "solana-sdk-macro"
 version = "1.14.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7f28d94a4ed37c6eb7c62221da0e2206f11af051e91c045f2cce60111d3020"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-client-custom-header#afc0ab648774a30f1a6d4100b9e2c53aae6079cf"
 dependencies = [
  "bs58 0.4.0",
  "proc-macro2 1.0.56",
@@ -5136,8 +5116,7 @@ dependencies = [
 [[package]]
 name = "solana-streamer"
 version = "1.14.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cc73adca6270314a92480d944d991f3697b4bd66322ea39233ee5102a7a6760"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-client-custom-header#afc0ab648774a30f1a6d4100b9e2c53aae6079cf"
 dependencies = [
  "crossbeam-channel",
  "futures-util",
@@ -5165,8 +5144,7 @@ dependencies = [
 [[package]]
 name = "solana-transaction-status"
 version = "1.14.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c614df6e742e7be647b05775b3a0414fc0570f009e180d86554b3d6797f77e"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-client-custom-header#afc0ab648774a30f1a6d4100b9e2c53aae6079cf"
 dependencies = [
  "Inflector",
  "base64 0.13.1",
@@ -5194,8 +5172,7 @@ dependencies = [
 [[package]]
 name = "solana-version"
 version = "1.14.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "359aecee536123048ae876b938688b4a87fa879bd1e8e752406f871656b98153"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-client-custom-header#afc0ab648774a30f1a6d4100b9e2c53aae6079cf"
 dependencies = [
  "log",
  "rustc_version",
@@ -5210,8 +5187,7 @@ dependencies = [
 [[package]]
 name = "solana-vote-program"
 version = "1.14.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68586a5b4862cd840a4e3e17d8428714a0f01757e5221b1d6ac1dd3ba2237b9b"
+source = "git+https://github.com/rpcpool/solana-public.git?tag=v1.14.15-client-custom-header#afc0ab648774a30f1a6d4100b9e2c53aae6079cf"
 dependencies = [
  "bincode",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,13 @@ exclude = [
   "migration",
 ]
 
+[patch.crates-io]
+solana-account-decoder = { git = "https://github.com/rpcpool/solana-public.git", tag = "v1.14.15-client-custom-header" }
+solana-client = { git = "https://github.com/rpcpool/solana-public.git", tag = "v1.14.15-client-custom-header" }
+solana-program = { git = "https://github.com/rpcpool/solana-public.git", tag = "v1.14.15-client-custom-header" }
+solana-sdk = { git = "https://github.com/rpcpool/solana-public.git", tag = "v1.14.15-client-custom-header" }
+solana-transaction-status = { git = "https://github.com/rpcpool/solana-public.git", tag = "v1.14.15-client-custom-header" }
+
 [profile.release]
 lto = true
 codegen-units = 1

--- a/tests/acc_forwarder/src/main.rs
+++ b/tests/acc_forwarder/src/main.rs
@@ -30,7 +30,9 @@ use {
     },
     std::{collections::HashSet, env, str::FromStr, sync::Arc},
     tokio::{sync::Mutex, time::Duration},
-    txn_forwarder::{find_signatures, read_lines, rpc_send_with_retries, save_metrics},
+    txn_forwarder::{
+        find_signatures, read_lines, rpc_client_with_header, rpc_send_with_retries, save_metrics,
+    },
 };
 
 lazy_static::lazy_static! {
@@ -44,17 +46,25 @@ lazy_static::lazy_static! {
 struct Args {
     #[arg(long)]
     redis_url: String,
+
+    /// Solana RPC endpoint.
+    #[arg(long, alias = "rpc-url")]
+    rpc: String,
+    /// Custom header in request to Solana RPC.
     #[arg(long)]
-    rpc_url: String,
+    rpc_custom_header: Option<String>,
+
     /// Size of signatures queue
     #[arg(long, default_value_t = 25_000)]
     signatures_history_queue: usize,
+
     /// Path to prometheus output
     #[arg(long)]
     prom: Option<String>,
     /// Prometheus metrics file update interval
     #[arg(long, default_value_t = 1_000)]
     prom_save_interval: u64,
+
     #[command(subcommand)]
     action: Action,
 }
@@ -132,7 +142,7 @@ async fn main() -> anyhow::Result<()> {
         Duration::from_millis(args.prom_save_interval),
     );
 
-    let client = RpcClient::new(args.rpc_url.clone());
+    let client = RpcClient::new(args.rpc.clone());
 
     match args.action {
         Action::Single { account } => {
@@ -172,7 +182,7 @@ async fn main() -> anyhow::Result<()> {
                 .with_context(|| format!("failed to parse collection {collection}"))?;
             let stream = Arc::new(Mutex::new(find_signatures(
                 collection,
-                client,
+                rpc_client_with_header(args.rpc.clone(), args.rpc_custom_header)?,
                 3, // max_retries
                 args.signatures_history_queue,
             )));
@@ -180,7 +190,7 @@ async fn main() -> anyhow::Result<()> {
             try_join_all((0..concurrency).map(|_| {
                 let metadata_accounts = Arc::clone(&metadata_accounts);
                 let stream = Arc::clone(&stream);
-                let client = RpcClient::new(args.rpc_url.clone());
+                let client = RpcClient::new(args.rpc.clone());
                 let messenger = Arc::clone(&messenger);
                 async move {
                     loop {

--- a/tests/acc_forwarder/src/main.rs
+++ b/tests/acc_forwarder/src/main.rs
@@ -173,6 +173,7 @@ async fn main() -> anyhow::Result<()> {
             let stream = Arc::new(Mutex::new(find_signatures(
                 collection,
                 client,
+                3, // max_retries
                 args.signatures_history_queue,
             )));
 

--- a/tests/tree-status/src/main.rs
+++ b/tests/tree-status/src/main.rs
@@ -53,7 +53,9 @@ use {
         task::JoinSet,
         time::Duration,
     },
-    txn_forwarder::{find_signatures, read_lines, rpc_send_with_retries, save_metrics},
+    txn_forwarder::{
+        find_signatures, read_lines, rpc_client_with_header, rpc_send_with_retries, save_metrics,
+    },
 };
 
 lazy_static::lazy_static! {
@@ -125,6 +127,9 @@ struct Args {
     /// Solana RPC endpoint.
     #[arg(long, short, alias = "rpc-url")]
     rpc: String,
+    /// Custom header in request to Solana RPC.
+    #[arg(long)]
+    rpc_custom_header: Option<String>,
 
     /// Number of concurrent requests for fetching transactions.
     #[arg(long, default_value_t = 25)]
@@ -335,6 +340,7 @@ async fn main() -> anyhow::Result<()> {
                     }
                 }
                 let rpc = args.rpc.clone();
+                let rpc_custom_header = args.rpc_custom_header.clone();
                 let concurrency_tx = concurrency_tx.clone();
                 let conn = args.get_pg_conn().await?;
                 let tx = Arc::clone(&tx);
@@ -343,6 +349,7 @@ async fn main() -> anyhow::Result<()> {
                     if let Err(error) = check_tree_leafs(
                         pubkey,
                         &rpc,
+                        rpc_custom_header,
                         signatures_history_queue,
                         concurrency_tx,
                         max_retries,
@@ -370,12 +377,14 @@ async fn main() -> anyhow::Result<()> {
                     tasks_tree.join_next().await;
                 }
                 let rpc = args.rpc.clone();
+                let rpc_custom_header = args.rpc_custom_header.clone();
                 let concurrency_tx = concurrency_tx.clone();
                 tasks_tree.spawn(async move {
                     info!("showing tree {pubkey}, hex: {}", hex::encode(pubkey));
                     if let Err(error) = read_tree(
                         pubkey,
                         &rpc,
+                        rpc_custom_header,
                         signatures_history_queue,
                         concurrency_tx,
                         max_retries,
@@ -521,9 +530,11 @@ WHERE
         .collect())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn check_tree_leafs(
     pubkey: Pubkey,
-    client_url: &str,
+    rpc: &str,
+    rpc_custom_header: Option<String>,
     signatures_history_queue: usize,
     concurrency_tx: (usize, Arc<Semaphore>),
     max_retries: u8,
@@ -532,11 +543,12 @@ async fn check_tree_leafs(
 ) -> anyhow::Result<()> {
     let (fetch_fut, mut leafs_rx) = read_tree_start(
         pubkey,
-        client_url,
+        rpc,
+        rpc_custom_header,
         signatures_history_queue,
         concurrency_tx,
         max_retries,
-    );
+    )?;
     try_join(fetch_fut, async move {
         // collect max seq per leaf index from transactions
         let mut leafs = HashMap::new();
@@ -621,7 +633,8 @@ GROUP BY
 // Fetches all the transactions referencing a specific trees
 async fn read_tree(
     pubkey: Pubkey,
-    client_url: &str,
+    rpc: &str,
+    rpc_custom_header: Option<String>,
     signatures_history_queue: usize,
     concurrency_tx: (usize, Arc<Semaphore>),
     max_retries: u8,
@@ -635,11 +648,12 @@ async fn read_tree(
 
     let (fetch_fut, mut print_rx) = read_tree_start(
         pubkey,
-        client_url,
+        rpc,
+        rpc_custom_header,
         signatures_history_queue,
         concurrency_tx,
         max_retries,
-    );
+    )?;
     try_join(fetch_fut, async move {
         let mut next_id = 0;
         let mut map = HashMap::new();
@@ -668,18 +682,19 @@ async fn read_tree(
 #[allow(clippy::type_complexity)]
 fn read_tree_start(
     pubkey: Pubkey,
-    client_url: &str,
+    rpc: &str,
+    rpc_custom_header: Option<String>,
     signatures_history_queue: usize,
     (concurrency_tx_max, concurrency_tx): (usize, Arc<Semaphore>),
     max_retries: u8,
-) -> (
+) -> anyhow::Result<(
     BoxFuture<'static, anyhow::Result<()>>,
     mpsc::UnboundedReceiver<(usize, Signature, Vec<(u64, MaybeLeafNode)>)>,
-) {
+)> {
     let sig_id = Arc::new(AtomicUsize::new(0));
     let rx_sig = Arc::new(Mutex::new(find_signatures(
         pubkey,
-        RpcClient::new(client_url.to_owned()),
+        rpc_client_with_header(rpc.to_owned(), rpc_custom_header)?,
         max_retries,
         signatures_history_queue,
     )));
@@ -691,7 +706,7 @@ fn read_tree_start(
         .map(|_| {
             let sig_id = Arc::clone(&sig_id);
             let rx_sig = Arc::clone(&rx_sig);
-            let client = RpcClient::new(client_url.to_owned());
+            let client = RpcClient::new(rpc.to_owned());
             let concurrency_tx = Arc::clone(&concurrency_tx);
             let tx = Arc::clone(&tx);
             async move {
@@ -719,7 +734,7 @@ fn read_tree_start(
         .collect::<Vec<_>>();
     drop(tx);
 
-    (try_join_all(fetch_futs).map_ok(|_| ()).boxed(), rx)
+    Ok((try_join_all(fetch_futs).map_ok(|_| ()).boxed(), rx))
 }
 
 // Process and individual transaction, fetching it and reading out the sequence numbers

--- a/tests/tree-status/src/main.rs
+++ b/tests/tree-status/src/main.rs
@@ -680,6 +680,7 @@ fn read_tree_start(
     let rx_sig = Arc::new(Mutex::new(find_signatures(
         pubkey,
         RpcClient::new(client_url.to_owned()),
+        max_retries,
         signatures_history_queue,
     )));
 

--- a/tests/txn_forwarder/src/lib.rs
+++ b/tests/txn_forwarder/src/lib.rs
@@ -26,6 +26,21 @@ use {
     tokio_stream::wrappers::LinesStream,
 };
 
+pub fn rpc_client_with_header(url: String, header: Option<String>) -> anyhow::Result<RpcClient> {
+    Ok(if let Some(header) = header {
+        let mut items = header.splitn(2, ':');
+        let name = items
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("expect header name"))?;
+        let value = items
+            .next()
+            .ok_or_else(|| anyhow::anyhow!("expect header value"))?;
+        RpcClient::new_with_header(url, name, value)
+    } else {
+        RpcClient::new(url)
+    })
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum FindSignaturesError {
     #[error("Failed to fetch signatures: {0}")]

--- a/tests/txn_forwarder/src/main.rs
+++ b/tests/txn_forwarder/src/main.rs
@@ -30,7 +30,9 @@ use {
         sync::{mpsc, Mutex},
         time::Duration,
     },
-    txn_forwarder::{find_signatures, read_lines, rpc_send_with_retries, save_metrics},
+    txn_forwarder::{
+        find_signatures, read_lines, rpc_client_with_header, rpc_send_with_retries, save_metrics,
+    },
 };
 
 lazy_static::lazy_static! {
@@ -45,18 +47,28 @@ lazy_static::lazy_static! {
 struct Cli {
     #[arg(long)]
     redis_url: String,
+
+    /// Solana RPC endpoint.
+    #[arg(long, alias = "rpc-url")]
+    rpc: String,
+    /// Custom header in request to Solana RPC.
     #[arg(long)]
-    rpc_url: String,
+    rpc_custom_header: Option<String>,
+
     #[arg(long, short, default_value_t = 25)]
     concurrency: usize,
+
     /// Size of Redis connections pool
     #[arg(long, default_value_t = 25)]
     concurrency_redis: usize,
+
     /// Size of signatures queue
     #[arg(long, default_value_t = 25_000)]
     signatures_history_queue: usize,
+
     #[arg(long, short, default_value_t = 3)]
     max_retries: u8,
+
     #[arg(long)]
     prom_group: Option<String>,
     /// Path to prometheus output
@@ -65,6 +77,7 @@ struct Cli {
     /// Prometheus metrics file update interval
     #[arg(long, default_value_t = 1_000)]
     prom_save_interval: u64,
+
     #[command(subcommand)]
     action: Action,
 }
@@ -207,7 +220,8 @@ async fn main() -> anyhow::Result<()> {
                     tx.send(
                         send_address(
                             pubkey,
-                            cli.rpc_url,
+                            cli.rpc,
+                            cli.rpc_custom_header,
                             messenger,
                             cli.signatures_history_queue,
                             cli.max_retries,
@@ -233,12 +247,14 @@ async fn main() -> anyhow::Result<()> {
                         continue;
                     }
                 };
-                let rpc_url = cli.rpc_url.clone();
+                let rpc_url = cli.rpc.clone();
+                let rpc_custom_header = cli.rpc_custom_header.clone();
                 let messenger = messenger.clone();
                 tx.send(
                     send_address(
                         pubkey,
                         rpc_url,
+                        rpc_custom_header,
                         messenger,
                         cli.signatures_history_queue,
                         cli.max_retries,
@@ -252,7 +268,7 @@ async fn main() -> anyhow::Result<()> {
         Action::Single { txn } => {
             match Signature::from_str(&txn) {
                 Ok(sig) => tx
-                    .send(send_tx(None, sig, cli.rpc_url, cli.max_retries, messenger).boxed())
+                    .send(send_tx(None, sig, cli.rpc, cli.max_retries, messenger).boxed())
                     .map_err(|_| anyhow::anyhow!("failed to send job"))?,
                 Err(_error) => {
                     error!("failed to parse signature: {txn:?}");
@@ -270,7 +286,7 @@ async fn main() -> anyhow::Result<()> {
                         continue;
                     }
                 };
-                let rpc_url = cli.rpc_url.clone();
+                let rpc_url = cli.rpc.clone();
                 let messenger = messenger.clone();
                 tx.send(send_tx(None, sig, rpc_url, cli.max_retries, messenger).boxed())
                     .map_err(|_| anyhow::anyhow!("failed to send job"))?;
@@ -303,12 +319,13 @@ async fn main() -> anyhow::Result<()> {
 async fn send_address(
     pubkey: Pubkey,
     rpc_url: String,
+    rpc_custom_header: Option<String>,
     messenger: MessengerPool,
     signatures_history_queue: usize,
     max_retries: u8,
     tasks_tx: mpsc::UnboundedSender<BoxFuture<'static, anyhow::Result<()>>>,
 ) -> anyhow::Result<()> {
-    let client = RpcClient::new(rpc_url.clone());
+    let client = rpc_client_with_header(rpc_url.clone(), rpc_custom_header)?;
     let mut all_sig = find_signatures(pubkey, client, max_retries, signatures_history_queue);
     while let Some(sig) = all_sig.recv().await {
         let rpc_url = rpc_url.clone();

--- a/tests/txn_forwarder/src/main.rs
+++ b/tests/txn_forwarder/src/main.rs
@@ -309,7 +309,7 @@ async fn send_address(
     tasks_tx: mpsc::UnboundedSender<BoxFuture<'static, anyhow::Result<()>>>,
 ) -> anyhow::Result<()> {
     let client = RpcClient::new(rpc_url.clone());
-    let mut all_sig = find_signatures(pubkey, client, signatures_history_queue);
+    let mut all_sig = find_signatures(pubkey, client, max_retries, signatures_history_queue);
     while let Some(sig) = all_sig.recv().await {
         let rpc_url = rpc_url.clone();
         let messenger = messenger.clone();


### PR DESCRIPTION
Allow to pass custom header to our patched validator :wink: 

I needed to patch `solana-client` for custom header support.

Plus added retries for `getSFA`.