### PR TITLE
Stop SPL Asset Table Spam

### DIFF
--- a/nft_ingester/src/program_transformers/token/mod.rs
+++ b/nft_ingester/src/program_transformers/token/mod.rs
@@ -74,7 +74,9 @@ pub async fn handle_token_program_account<'a, 'b, 'c>(
                 .await?;
             if let Some(asset) = asset_update {
                 // will only update owner if token account balance is non-zero
-                if ta.amount > 0 {
+                // since the asset is marked as single then the token account balance can only be 1. Greater implies a fungible token in which case no si
+                // TODO: this does not guarantee in case when wallet receives an amount of 1 for a token but its supply is more. is unlikely since mints often have a decimal
+                if ta.amount == 1 {
                     let mut active: asset::ActiveModel = asset.into();
                     active.owner = Set(Some(owner));
                     active.delegate = Set(delegate);


### PR DESCRIPTION
## Issue
Many SPL tokens have an associated metadata account but lack a defined `token_standard`. The current ingester version incorrectly categorizes such SPL tokens as having an `ownership_type` due to this undefined `token_standard`. The `token_account_update` handler, responsible for account changes, references the associated `asset`. If the `token_account`'s held amount is `t.amount > 0 AND asset.ownership_type == OwnerType::Single`, the asset's owner field updates to the token account's owner. This leads to SPL token exchanges triggering frequent ownership updates on the asset, resulting in excessive single-row updates in the database. These updates cause locks that severely hamper the database's message processing capabilities, leading to queue backups.

```
2023-11-28 10:18:36.994 UTC [3417847] plerkle@plerkle DETAIL:  parameters: $1 = '\xbb683d0a860abfd4ebca3168639e1040373293ad4e1e1c8aa4f86775adb28641', $2 = NULL, $3 = 'f', $4 = '\x0b3338a0ab2cc841d5b014bc6a3cf756291874b319c9517d9bbfa9e4e9661ef9'
2023-11-28 10:18:36.997 UTC [3417883] plerkle@plerkle LOG:  duration: 117.646 ms  execute sqlx_s_11: UPDATE "asset" SET "owner" = $1, "delegate" = $2, "frozen" = $3 WHERE "asset"."id" = $4 RETURNING "id", "alt_id", CAST("specification_version" AS text), CAST("specification_asset_class" AS text), "owner", CAST("owner_type" AS text), "delegate", "frozen", "supply", "supply_mint", "compressed", "compressible", "seq", "tree_id", "leaf", "nonce", CAST("royalty_target_type" AS text), "royalty_target", "royalty_amount", "asset_data", "created_at", "burnt", "slot_updated", "data_hash", "creator_hash", "owner_delegate_seq", "was_decompressed", "leaf_seq"
2023-11-28 10:18:36.997 UTC [3417883] plerkle@plerkle DETAIL:  parameters: $1 = '\x606f89bd892ea03ce24def538a118b5902d5beadbb20799b861b2ec193d1c137', $2 = NULL, $3 = 'f', $4 = '\x0b3338a0ab2cc841d5b014bc6a3cf756291874b319c9517d9bbfa9e4e9661ef9'
2023-11-28 10:18:36.999 UTC [3417853] plerkle@plerkle LOG:  duration: 181.551 ms  execute sqlx_s_3: UPDATE "asset" SET "owner" = $1, "delegate" = $2, "frozen" = $3 WHERE "asset"."id" = $4 RETURNING "id", "alt_id", CAST("specification_version" AS text), CAST("specification_asset_class" AS text), "owner", CAST("owner_type" AS text), "delegate", "frozen", "supply", "supply_mint", "compressed", "compressible", "seq", "tree_id", "leaf", "nonce", CAST("royalty_target_type" AS text), "royalty_target", "royalty_amount", "asset_data", "created_at", "burnt", "slot_updated", "data_hash", "creator_hash", "owner_delegate_seq", "was_decompressed", "leaf_seq"
2023-11-28 10:18:36.999 UTC [3417853] plerkle@plerkle DETAIL:  parameters: $1 = '\x89141ae251369cff9815734ef0bc7d1258cabcbbdc7cdbfd9935e298e6317c23', $2 = NULL, $3 = 'f', $4 = '\x0b3338a0ab2cc841d5b014bc6a3cf756291874b319c9517d9bbfa9e4e9661ef9'
2023-11-28 10:18:37.001 UTC [3417905] plerkle@plerkle LOG:  duration: 114.327 ms  execute sqlx_s_7: UPDATE "asset" SET "owner" = $1, "delegate" = $2, "frozen" = $3 WHERE "asset"."id" = $4 RETURNING "id", "alt_id", CAST("specification_version" AS text), CAST("specification_asset_class" AS text), "owner", CAST("owner_type" AS text), "delegate", "frozen", "supply", "supply_mint", "compressed", "compressible", "seq", "tree_id", "leaf", "nonce", CAST("royalty_target_type" AS text), "royalty_target", "royalty_amount", "asset_data", "created_at", "burnt", "slot_updated", "data_hash", "creator_hash", "owner_delegate_seq", "was_decompressed", "leaf_seq"
2023-11-28 10:18:37.001 UTC [3417905] plerkle@plerkle DETAIL:  parameters: $1 = '\xd4636646ddc9498649514154f9d3f3b4d25a474ca36a106ffe8a7b8a0e4b2d20', $2 = NULL, $3 = 'f', $4 = '\x0b3338a0ab2cc841d5b014bc6a3cf756291874b319c9517d9bbfa9e4e9661ef9'
2023-11-28 10:18:37.003 UTC [3417822] plerkle@plerkle LOG:  duration: 82.452 ms  execute sqlx_s_3: UPDATE "asset" SET "owner" = $1, "delegate" = $2, "frozen" = $3 WHERE "asset"."id" = $4 RETURNING "id", "alt_id", CAST("specification_version" AS text), CAST("specification_asset_class" AS text), "owner", CAST("owner_type" AS text), "delegate", "frozen", "supply", "supply_mint", "compressed", "compressible", "seq", "tree_id", "leaf", "nonce", CAST("royalty_target_type" AS text), "royalty_target", "royalty_amount", "asset_data", "created_at", "burnt", "slot_updated", "data_hash", "creator_hash", "owner_delegate_seq", "was_decompressed", "leaf_seq"
```

## Fix
The logic dictating when an asset is marked as single and an associated token account update occurs. Ownership changes now only trigger when the amount is exactly 1. Additionally, when saving an asset where the single ownership case is activated, only token accounts with an amount of 1 are returned. Changes in single ownership should exclusively represent the exchange of 1 amount between token accounts. Values exceeding 1 inherently suggest the token is fungible.

## Disclaimer
This approach is not entirely accurate logically, as fungible tokens can experience a transfer scenario where exactly 1 unit is exchanged. However, this is highly improbable in practice, considering that mints typically have a decimal field where 1 "token" represents an amount of 1,000,000.

While this PR doesn't rectify the incorrect assignment of SPL tokens when `token_standard` is unset, it effectively prevents unnecessary ownership updates from being triggered.

