### PR TITLE
Remove use of tree_transactions from the backfiller

### DIFF
--- a/nft_ingester/src/program_transformers/bubblegum/mod.rs
+++ b/nft_ingester/src/program_transformers/bubblegum/mod.rs
@@ -99,16 +99,6 @@ where
         }
         _ => debug!("Bubblegum: Not Implemented Instruction"),
     }
-    // TODO: assuming tree update available on all transactions but need to confirm.
-    if let Some(tree_update) = &parsing_result.tree_update {
-        save_tree_transaction(
-            tree_update.id.to_bytes().to_vec(),
-            bundle.slot,
-            bundle.txn_id,
-            txn,
-        )
-        .await?;
-    }
 
     Ok(())
 }

--- a/tree_backfiller/src/rpc.rs
+++ b/tree_backfiller/src/rpc.rs
@@ -62,7 +62,6 @@ impl Rpc {
         &self,
         pubkey: &Pubkey,
         before: Option<Signature>,
-        until: Option<Signature>,
     ) -> Result<Vec<RpcConfirmedTransactionStatusWithSignature>, ClientError> {
         (|| async {
             self.0
@@ -70,7 +69,6 @@ impl Rpc {
                     pubkey,
                     GetConfirmedSignaturesForAddress2Config {
                         before,
-                        until,
                         commitment: Some(CommitmentConfig {
                             commitment: CommitmentLevel::Finalized,
                         }),


### PR DESCRIPTION
## Changes
- Remove the use of tree_transactions to assist in backfilling but similar info is available on cl_items and cl_audits (if enabled).
