### PR TITLE
[Patch] Filter out failed transactions while tree backfilling #175

### DIFF
--- a/ops/src/bubblegum/audit.rs
+++ b/ops/src/bubblegum/audit.rs
@@ -1,0 +1,91 @@
+use super::rpc::{Rpc, SolanaRpcArgs};
+use anyhow::Result;
+
+use clap::Parser;
+use das_core::{connect_db, MetricsArgs, PoolArgs};
+use digital_asset_types::dao::cl_audits_v2;
+use futures::future;
+
+use sea_orm::{CursorTrait, EntityTrait, SqlxPostgresConnector};
+use solana_sdk::signature::Signature;
+use solana_transaction_status::EncodedConfirmedTransactionWithStatusMeta;
+
+use tokio::io::{stdout, AsyncWriteExt};
+
+#[derive(Debug, Parser, Clone)]
+pub struct Args {
+    /// Database configuration
+    #[clap(flatten)]
+    pub database: PoolArgs,
+
+    /// Metrics configuration
+    #[clap(flatten)]
+    pub metrics: MetricsArgs,
+
+    /// Solana configuration
+    #[clap(flatten)]
+    pub solana: SolanaRpcArgs,
+
+    #[arg(long, env, default_value = "10000")]
+    pub batch_size: u64,
+}
+
+pub async fn run(config: Args) -> Result<()> {
+    let pool = connect_db(config.database).await?;
+
+    let solana_rpc = Rpc::from_config(config.solana);
+
+    let mut output = stdout();
+    let conn = SqlxPostgresConnector::from_sqlx_postgres_pool(pool);
+    let mut after = None;
+
+    loop {
+        let mut query = cl_audits_v2::Entity::find().cursor_by(cl_audits_v2::Column::Id);
+        let mut query = query.first(config.batch_size);
+
+        if let Some(after) = after {
+            query = query.after(after);
+        }
+
+        let entries = query.all(&conn).await?;
+
+        let mut transactions = vec![];
+
+        for entry in entries.clone() {
+            transactions.push(fetch_transaction(entry, solana_rpc.clone()));
+        }
+
+        let transactions = future::join_all(transactions).await;
+
+        for (signature, transaction) in transactions.into_iter().flatten() {
+            if let Some(meta) = transaction.transaction.meta {
+                if meta.err.is_some() {
+                    output
+                        .write_all(format!("{}\n", signature).as_bytes())
+                        .await?;
+
+                    output.flush().await?;
+                }
+            }
+        }
+
+        after = entries.last().map(|cl_audit_v2| cl_audit_v2.id);
+
+        if entries.is_empty() {
+            break;
+        }
+    }
+
+    Ok(())
+}
+
+async fn fetch_transaction(
+    entry: cl_audits_v2::Model,
+    solana_rpc: Rpc,
+) -> Result<(Signature, EncodedConfirmedTransactionWithStatusMeta)> {
+    let signature = Signature::try_from(entry.tx.as_ref())?;
+
+    let transaction = solana_rpc.get_transaction(&signature).await?;
+
+    Ok((signature, transaction))
+}

--- a/ops/src/bubblegum/cmd.rs
+++ b/ops/src/bubblegum/cmd.rs
@@ -1,4 +1,4 @@
-use super::backfiller;
+use super::{audit, backfiller};
 use anyhow::Result;
 use clap::{Args, Subcommand};
 
@@ -8,6 +8,9 @@ pub enum Commands {
     /// It crawls through trees and backfills any missed tree transactions.
     #[clap(name = "backfill")]
     Backfill(backfiller::Args),
+    /// The `audit` commands checks `cl_audits_v2` for any failed transactions and logs them to stdout.
+    #[clap(name = "audit")]
+    Audit(audit::Args),
 }
 
 #[derive(Debug, Clone, Args)]
@@ -20,6 +23,9 @@ pub async fn subcommand(subcommand: BubblegumCommand) -> Result<()> {
     match subcommand.action {
         Commands::Backfill(args) => {
             backfiller::run(args).await?;
+        }
+        Commands::Audit(args) => {
+            audit::run(args).await?;
         }
     }
 

--- a/ops/src/bubblegum/mod.rs
+++ b/ops/src/bubblegum/mod.rs
@@ -1,3 +1,4 @@
+mod audit;
 mod backfiller;
 mod cmd;
 mod queue;


### PR DESCRIPTION
Issue
The backfiller was not filtering out failed transactions before pushing them for indexing which caused incorrect information to be indexed.

Fix
Add filter to remove failed transactions before pushing along to ingester.
Changes
Add audit command to ops bubblegum to identify failed transaction that made it into the index
