### PR TITLE
Config Max DB Connections

### DIFF
--- a/das_api/src/api/api_impl.rs
+++ b/das_api/src/api/api_impl.rs
@@ -40,7 +40,7 @@ pub struct DasApi {
 impl DasApi {
     pub async fn from_config(config: Config) -> Result<Self, DasApiError> {
         let pool = PgPoolOptions::new()
-            .max_connections(250)
+            .max_connections(config.max_database_connections.unwrap_or(250))
             .connect(&config.database_url)
             .await?;
 

--- a/das_api/src/config.rs
+++ b/das_api/src/config.rs
@@ -7,6 +7,7 @@ use {
 #[derive(Deserialize, Default)]
 pub struct Config {
     pub database_url: String,
+    pub max_database_connections: Option<u32>,
     pub metrics_port: Option<u16>,
     pub metrics_host: Option<String>,
     pub server_port: u16,


### PR DESCRIPTION
## Changes
- Add max_database_connections to read api with default being previous value of 250.
