### PR TITLE
No retries when looking up owner and token

### DIFF
--- a/nft_ingester/src/program_transformers/token_metadata/v1_asset.rs
+++ b/nft_ingester/src/program_transformers/token_metadata/v1_asset.rs
@@ -62,7 +62,7 @@ pub async fn burn_v1_asset<T: ConnectionTrait + TransactionTrait>(
     Ok(())
 }
 
-const RETRY_INTERVALS: &[u64] = &[0, 5, 10];
+const RETRY_INTERVALS: &[u64] = &[0];
 const WSOL_ADDRESS: &str = "So11111111111111111111111111111111111111112";
 
 lazy_static! {


### PR DESCRIPTION
## Changes
- Disable retries to test affect on ingestion rate when there is a backlog of messages in the queue.
