### PR TITLE
Add force flag to TreeWorkerArgs for complete reindexing

### DIFF
--- a/blockbuster/src/lib.rs
+++ b/blockbuster/src/lib.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 pub mod error;
 pub mod instruction;
 pub mod program_handler;

--- a/tools/acc_forwarder/src/main.rs
+++ b/tools/acc_forwarder/src/main.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use {
     anyhow::Context,
     clap::Parser,


### PR DESCRIPTION
## Description
This PR introduces a new `force` flag to the `TreeWorkerArgs` struct, allowing for a complete reindex of trees from the first transaction up to the current sequence number. When the force flag is set, the backfiller skips checking gaps in `cl_audits_v2`, effectively ignoring existing audit data and performing a full reindex.

## Changes
- Added a `force` boolean flag to `TreeWorkerArgs` struct
- Modified the `start` method in `TreeWorkerArgs` to use the force flag
- Removed queries to `cl_audits_v2` when force flag is set

## Motivation
This change allows for a complete reindex of trees.

## Notes for Reviewers
- The main logic change is in the `start` method of `TreeWorkerArgs`
- Pay attention to the handling of gaps when the force flag is set vs. when it's not
- Ensure that the existing functionality is preserved when the force flag is not used