### PR TITLE
Reset Redis Consumer

### DIFF
--- a/grpc-ingest/src/config.rs
+++ b/grpc-ingest/src/config.rs
@@ -57,6 +57,11 @@ pub struct ConfigIngestStream {
     )]
     pub max_concurrency: usize,
     #[serde(
+        default = "ConfigIngestStream::default_ack_concurrency",
+        deserialize_with = "deserialize_usize_str"
+    )]
+    pub ack_concurrency: usize,
+    #[serde(
         default = "ConfigIngestStream::default_xack_buffer_size",
         deserialize_with = "deserialize_usize_str"
     )]
@@ -69,6 +74,10 @@ impl ConfigIngestStream {
     }
     pub const fn default_max_concurrency() -> usize {
         2
+    }
+
+    pub const fn default_ack_concurrency() -> usize {
+        5
     }
 
     pub const fn default_xack_batch_max_idle() -> Duration {

--- a/grpc-ingest/src/ingester.rs
+++ b/grpc-ingest/src/ingester.rs
@@ -108,7 +108,8 @@ pub async fn run(config: ConfigIngester) -> anyhow::Result<()> {
                     .map_err(Into::into)
             })
         })
-        .start()?;
+        .start()
+        .await?;
     let account_stream = IngestStream::build()
         .config(config.accounts.clone())
         .connection(connection.clone())
@@ -124,7 +125,8 @@ pub async fn run(config: ConfigIngester) -> anyhow::Result<()> {
                     .map_err(Into::into)
             })
         })
-        .start()?;
+        .start()
+        .await?;
     let transactions_stream = IngestStream::build()
         .config(config.transactions.clone())
         .connection(connection.clone())
@@ -140,7 +142,8 @@ pub async fn run(config: ConfigIngester) -> anyhow::Result<()> {
                     .map_err(Into::into)
             })
         })
-        .start()?;
+        .start()
+        .await?;
     let snapshot_stream = IngestStream::build()
         .config(config.snapshots.clone())
         .connection(connection.clone())
@@ -156,7 +159,8 @@ pub async fn run(config: ConfigIngester) -> anyhow::Result<()> {
                     .map_err(Into::into)
             })
         })
-        .start()?;
+        .start()
+        .await?;
 
     let mut shutdown = create_shutdown()?;
 


### PR DESCRIPTION
## Changes
- When stream starts delete and recreate the consumer so pending messages is reset. By doing this you don't need to track pending messages and use xread starting from 0.
