### PR TITLE
Back Pressure XRead

### DIFF
--- a/grpc-ingest/config-ingester.yml
+++ b/grpc-ingest/config-ingester.yml
@@ -3,19 +3,21 @@ redis: redis://localhost:6379
 postgres:
   url: postgres://solana:solana@localhost/solana
   min_connections: 10
-  max_connections: 50 # `max_connection` should be bigger than `program_transformer.max_tasks_in_process` otherwise unresolved lock is possible
+  max_connections: 50
 snapshots:
   name: SNAPSHOTS
   max_concurrency: 10
   batch_size: 100
   xack_batch_max_idle_ms: 1_000
   xack_buffer_size: 10_000
+  xack_batch_max_size: 500
 accounts:
   name: ACCOUNTS
   max_concurrency: 10
   batch_size: 100
   xack_batch_max_idle_ms: 1_000
   xack_buffer_size: 10_000
+  xack_batch_max_size: 500
 transactions:
   name: TRANSACTIONS
 download_metadata:

--- a/grpc-ingest/src/ingester.rs
+++ b/grpc-ingest/src/ingester.rs
@@ -122,10 +122,11 @@ pub async fn run(config: ConfigIngester) -> anyhow::Result<()> {
 
     report.abort();
 
-    accounts.stop().await?;
-    transactions.stop().await?;
+    futures::future::join_all(vec![accounts.stop(), transactions.stop(), snapshots.stop()])
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()?;
     download_metadatas.stop().await?;
-    snapshots.stop().await?;
 
     pool.close().await;
 

--- a/grpc-ingest/src/prom.rs
+++ b/grpc-ingest/src/prom.rs
@@ -62,6 +62,16 @@ lazy_static::lazy_static! {
         Opts::new("ingest_tasks", "Number of tasks spawned for ingest"),
         &["stream"]
     ).unwrap();
+
+    static ref ACK_TASKS: IntGaugeVec = IntGaugeVec::new(
+        Opts::new("ack_tasks", "Number of tasks spawned for ack redis messages"),
+        &["stream"]
+    ).unwrap();
+
+    static ref GRPC_TASKS: IntGaugeVec = IntGaugeVec::new(
+        Opts::new("grpc_tasks", "Number of tasks spawned for writing grpc messages to redis "),
+        &[]
+    ).unwrap();
 }
 
 pub fn run_server(address: SocketAddr) -> anyhow::Result<()> {
@@ -84,6 +94,8 @@ pub fn run_server(address: SocketAddr) -> anyhow::Result<()> {
         register!(PROGRAM_TRANSFORMER_TASK_STATUS_COUNT);
         register!(DOWNLOAD_METADATA_INSERTED_COUNT);
         register!(INGEST_TASKS);
+        register!(ACK_TASKS);
+        register!(GRPC_TASKS);
 
         VERSION_INFO_METRIC
             .with_label_values(&[
@@ -182,8 +194,20 @@ pub fn ingest_tasks_total_dec(stream: &str) {
     INGEST_TASKS.with_label_values(&[stream]).dec()
 }
 
-pub fn ingest_tasks_reset(stream: &str) {
-    INGEST_TASKS.with_label_values(&[stream]).set(0)
+pub fn ack_tasks_total_inc(stream: &str) {
+    ACK_TASKS.with_label_values(&[stream]).inc()
+}
+
+pub fn ack_tasks_total_dec(stream: &str) {
+    ACK_TASKS.with_label_values(&[stream]).dec()
+}
+
+pub fn grpc_tasks_total_inc() {
+    GRPC_TASKS.with_label_values(&[]).inc()
+}
+
+pub fn grpc_tasks_total_dec() {
+    GRPC_TASKS.with_label_values(&[]).dec()
 }
 
 #[derive(Debug, Clone, Copy)]


### PR DESCRIPTION
## Issue
The ingester reads messages far faster than they can be xack and xdel by redis. As the ingester run the executor gets overwhelmed with messages which cause it to slow down as more messages accumulate in its buffer.

## Changes
- Only read another page of messages if the ack channel has capacity
- Track all tasks grc and ack