### PR TITLE
Recreate consumer but not groups

### DIFF
--- a/grpc-ingest/config-ingester.yml
+++ b/grpc-ingest/config-ingester.yml
@@ -31,6 +31,8 @@ snapshots:
   xack_batch_max_size: 500
   # maximum number of redis messages to keep to buffer.
   messages_buffer_size: 200
+  # redis stream consumer name must be unique per ingester process
+  consumer: consumer
 
 # accounts configuration for the ingester
 accounts:
@@ -50,5 +52,4 @@ download_metadata:
   # maximum number of attempts for downloading metadata JSON.
   max_attempts: 1
   stream:
-    # stream name
     name: METADATA_JSON


### PR DESCRIPTION
## Changes
- Always create the stream consumer group. Recreate the consumer based on its configured named in the config.
