### PR TITLE
Wite CL Items in the transactions

### DIFF
--- a/program_transformers/src/bubblegum/creator_verification.rs
+++ b/program_transformers/src/bubblegum/creator_verification.rs
@@ -59,7 +59,12 @@ where
             "Handling creator verification event for creator {} (verify: {}): {}",
             creator, verify, bundle.txn_id
         );
-        let seq = save_changelog_event(cl, bundle.slot, bundle.txn_id, txn, instruction).await?;
+        // Begin a transaction.  If the transaction goes out of scope (i.e. one of the executions has
+        // an error and this function returns it using the `?` operator), then the transaction is
+        // automatically rolled back.
+        let multi_txn = txn.begin().await?;
+        let seq =
+            save_changelog_event(cl, bundle.slot, bundle.txn_id, &multi_txn, instruction).await?;
 
         match le.schema {
             LeafSchema::V1 {
@@ -78,11 +83,6 @@ where
                 };
                 let tree_id = cl.id.to_bytes();
                 let nonce = cl.index as i64;
-
-                // Begin a transaction.  If the transaction goes out of scope (i.e. one of the executions has
-                // an error and this function returns it using the `?` operator), then the transaction is
-                // automatically rolled back.
-                let multi_txn = txn.begin().await?;
 
                 // Partial update of asset table with just leaf info.
                 upsert_asset_with_leaf_info(

--- a/program_transformers/src/bubblegum/delegate.rs
+++ b/program_transformers/src/bubblegum/delegate.rs
@@ -23,7 +23,14 @@ where
     T: ConnectionTrait + TransactionTrait,
 {
     if let (Some(le), Some(cl)) = (&parsing_result.leaf_update, &parsing_result.tree_update) {
-        let seq = save_changelog_event(cl, bundle.slot, bundle.txn_id, txn, instruction).await?;
+        // Begin a transaction.  If the transaction goes out of scope (i.e. one of the executions has
+        // an error and this function returns it using the `?` operator), then the transaction is
+        // automatically rolled back.
+        let multi_txn = txn.begin().await?;
+
+        let seq =
+            save_changelog_event(cl, bundle.slot, bundle.txn_id, &multi_txn, instruction).await?;
+
         match le.schema {
             LeafSchema::V1 {
                 id,
@@ -39,11 +46,6 @@ where
                     Some(delegate.to_bytes().to_vec())
                 };
                 let tree_id = cl.id.to_bytes();
-
-                // Begin a transaction.  If the transaction goes out of scope (i.e. one of the executions has
-                // an error and this function returns it using the `?` operator), then the transaction is
-                // automatically rolled back.
-                let multi_txn = txn.begin().await?;
 
                 // Partial update of asset table with just leaf.
                 upsert_asset_with_leaf_info(

--- a/program_transformers/src/bubblegum/redeem.rs
+++ b/program_transformers/src/bubblegum/redeem.rs
@@ -22,7 +22,13 @@ where
     T: ConnectionTrait + TransactionTrait,
 {
     if let Some(cl) = &parsing_result.tree_update {
-        let seq = save_changelog_event(cl, bundle.slot, bundle.txn_id, txn, instruction).await?;
+        // Begin a transaction.  If the transaction goes out of scope (i.e. one of the executions has
+        // an error and this function returns it using the `?` operator), then the transaction is
+        // automatically rolled back.
+        let multi_txn = txn.begin().await?;
+
+        let seq =
+            save_changelog_event(cl, bundle.slot, bundle.txn_id, &multi_txn, instruction).await?;
         let leaf_index = cl.index;
         let (asset_id, _) = Pubkey::find_program_address(
             &[
@@ -36,11 +42,6 @@ where
         let id_bytes = asset_id.to_bytes();
         let tree_id = cl.id.to_bytes();
         let nonce = cl.index as i64;
-
-        // Begin a transaction.  If the transaction goes out of scope (i.e. one of the executions has
-        // an error and this function returns it using the `?` operator), then the transaction is
-        // automatically rolled back.
-        let multi_txn = txn.begin().await?;
 
         // Partial update of asset table with just leaf.
         upsert_asset_with_leaf_info(

--- a/program_transformers/src/token_metadata/v1_asset.rs
+++ b/program_transformers/src/token_metadata/v1_asset.rs
@@ -207,14 +207,13 @@ pub async fn save_v1_asset<T: ConnectionTrait + TransactionTrait>(
             OnConflict::columns([asset_authority::Column::AssetId])
                 .update_columns([
                     asset_authority::Column::Authority,
-                    asset_authority::Column::Seq,
                     asset_authority::Column::SlotUpdated,
                 ])
                 .to_owned(),
         )
         .build(DbBackend::Postgres);
     query.sql = format!(
-        "{} WHERE excluded.slot_updated > asset_authority.slot_updated",
+        "{} WHERE excluded.slot_updated > asset_authority.slot_updated AND excluded.authority != asset_authority.authority",
         query.sql
     );
     txn.execute(query)


### PR DESCRIPTION
## Changes
- Write the cli items in the transaction being taken out for the asset so each cl item isn't a round trip.

## Testing

Locally P90 before is 9 sec and after 1 sec

<img width="1501" alt="Screenshot 2024-12-16 at 6 36 58 PM" src="https://github.com/user-attachments/assets/a529717c-b8b8-489e-a882-eae557563991" />
