### PR TITLE
Only update the record when fields have changed for token and metadata programs

### DIFF
--- a/program_transformers/src/token/mod.rs
+++ b/program_transformers/src/token/mod.rs
@@ -10,8 +10,9 @@ use {
     blockbuster::programs::token_account::TokenProgramAccount,
     digital_asset_types::dao::{token_accounts, tokens},
     sea_orm::{
-        entity::ActiveValue, query::QueryTrait, sea_query::query::OnConflict, ConnectionTrait,
-        DatabaseConnection, DbBackend, EntityTrait, TransactionTrait,
+        entity::ActiveValue,
+        sea_query::{query::OnConflict, Alias, Expr},
+        Condition, DatabaseConnection, EntityTrait, TransactionTrait,
     },
     solana_sdk::program_option::COption,
     spl_token::state::AccountState,
@@ -49,7 +50,7 @@ pub async fn handle_token_program_account<'a, 'b>(
 
             let txn = db.begin().await?;
 
-            let mut query = token_accounts::Entity::insert(model)
+            token_accounts::Entity::insert(model)
                 .on_conflict(
                     OnConflict::columns([token_accounts::Column::Pubkey])
                         .update_columns([
@@ -60,17 +61,109 @@ pub async fn handle_token_program_account<'a, 'b>(
                             token_accounts::Column::Frozen,
                             token_accounts::Column::TokenProgram,
                             token_accounts::Column::Owner,
-                            token_accounts::Column::CloseAuthority,
                             token_accounts::Column::SlotUpdated,
                         ])
+                        .action_cond_where(
+                            Condition::all()
+                                .add(
+                                    Condition::any()
+                                        .add(
+                                            Expr::tbl(
+                                                Alias::new("excluded"),
+                                                token_accounts::Column::Mint,
+                                            )
+                                            .ne(
+                                                Expr::tbl(
+                                                    token_accounts::Entity,
+                                                    token_accounts::Column::Mint,
+                                                ),
+                                            ),
+                                        )
+                                        .add(
+                                            Expr::tbl(
+                                                Alias::new("excluded"),
+                                                token_accounts::Column::DelegatedAmount,
+                                            )
+                                            .ne(
+                                                Expr::tbl(
+                                                    token_accounts::Entity,
+                                                    token_accounts::Column::DelegatedAmount,
+                                                ),
+                                            ),
+                                        )
+                                        .add(
+                                            Expr::tbl(
+                                                Alias::new("excluded"),
+                                                token_accounts::Column::Delegate,
+                                            )
+                                            .ne(
+                                                Expr::tbl(
+                                                    token_accounts::Entity,
+                                                    token_accounts::Column::Delegate,
+                                                ),
+                                            ),
+                                        )
+                                        .add(
+                                            Expr::tbl(
+                                                Alias::new("excluded"),
+                                                token_accounts::Column::Amount,
+                                            )
+                                            .ne(
+                                                Expr::tbl(
+                                                    token_accounts::Entity,
+                                                    token_accounts::Column::Amount,
+                                                ),
+                                            ),
+                                        )
+                                        .add(
+                                            Expr::tbl(
+                                                Alias::new("excluded"),
+                                                token_accounts::Column::Frozen,
+                                            )
+                                            .ne(
+                                                Expr::tbl(
+                                                    token_accounts::Entity,
+                                                    token_accounts::Column::Frozen,
+                                                ),
+                                            ),
+                                        )
+                                        .add(
+                                            Expr::tbl(
+                                                Alias::new("excluded"),
+                                                token_accounts::Column::TokenProgram,
+                                            )
+                                            .ne(
+                                                Expr::tbl(
+                                                    token_accounts::Entity,
+                                                    token_accounts::Column::TokenProgram,
+                                                ),
+                                            ),
+                                        )
+                                        .add(
+                                            Expr::tbl(
+                                                Alias::new("excluded"),
+                                                token_accounts::Column::Owner,
+                                            )
+                                            .ne(
+                                                Expr::tbl(
+                                                    token_accounts::Entity,
+                                                    token_accounts::Column::Owner,
+                                                ),
+                                            ),
+                                        ),
+                                )
+                                .add(
+                                    Expr::tbl(
+                                        token_accounts::Entity,
+                                        token_accounts::Column::SlotUpdated,
+                                    )
+                                    .lte(account_info.slot as i64),
+                                ),
+                        )
                         .to_owned(),
                 )
-                .build(DbBackend::Postgres);
-            query.sql = format!(
-                "{} WHERE excluded.slot_updated > token_accounts.slot_updated",
-                query.sql
-            );
-            txn.execute(query).await?;
+                .exec_without_returning(&txn)
+                .await?;
 
             if ta.amount == 1 {
                 upsert_assets_token_account_columns(
@@ -112,29 +205,83 @@ pub async fn handle_token_program_account<'a, 'b>(
 
             let txn = db.begin().await?;
 
-            let mut query = tokens::Entity::insert(model)
+            tokens::Entity::insert(model)
                 .on_conflict(
                     OnConflict::columns([tokens::Column::Mint])
                         .update_columns([
                             tokens::Column::Supply,
                             tokens::Column::TokenProgram,
                             tokens::Column::MintAuthority,
-                            tokens::Column::CloseAuthority,
-                            tokens::Column::ExtensionData,
                             tokens::Column::SlotUpdated,
                             tokens::Column::Decimals,
                             tokens::Column::FreezeAuthority,
                         ])
+                        .action_cond_where(
+                            Condition::all()
+                                .add(
+                                    Condition::any()
+                                        .add(
+                                            Expr::tbl(
+                                                Alias::new("excluded"),
+                                                tokens::Column::Supply,
+                                            )
+                                            .ne(Expr::tbl(tokens::Entity, tokens::Column::Supply)),
+                                        )
+                                        .add(
+                                            Expr::tbl(
+                                                Alias::new("excluded"),
+                                                tokens::Column::TokenProgram,
+                                            )
+                                            .ne(
+                                                Expr::tbl(
+                                                    tokens::Entity,
+                                                    tokens::Column::TokenProgram,
+                                                ),
+                                            ),
+                                        )
+                                        .add(
+                                            Expr::tbl(
+                                                Alias::new("excluded"),
+                                                tokens::Column::MintAuthority,
+                                            )
+                                            .ne(
+                                                Expr::tbl(
+                                                    tokens::Entity,
+                                                    tokens::Column::MintAuthority,
+                                                ),
+                                            ),
+                                        )
+                                        .add(
+                                            Expr::tbl(
+                                                Alias::new("excluded"),
+                                                tokens::Column::Decimals,
+                                            )
+                                            .ne(
+                                                Expr::tbl(tokens::Entity, tokens::Column::Decimals),
+                                            ),
+                                        )
+                                        .add(
+                                            Expr::tbl(
+                                                Alias::new("excluded"),
+                                                tokens::Column::FreezeAuthority,
+                                            )
+                                            .ne(
+                                                Expr::tbl(
+                                                    tokens::Entity,
+                                                    tokens::Column::FreezeAuthority,
+                                                ),
+                                            ),
+                                        ),
+                                )
+                                .add(
+                                    Expr::tbl(tokens::Entity, tokens::Column::SlotUpdated)
+                                        .lte(account_info.slot as i64),
+                                ),
+                        )
                         .to_owned(),
                 )
-                .build(DbBackend::Postgres);
-
-            query.sql = format!(
-                "{} WHERE excluded.slot_updated >= tokens.slot_updated",
-                query.sql
-            );
-
-            txn.execute(query).await?;
+                .exec_without_returning(&txn)
+                .await?;
 
             upsert_assets_mint_account_columns(
                 AssetMintAccountColumns {

--- a/program_transformers/src/token_metadata/master_edition.rs
+++ b/program_transformers/src/token_metadata/master_edition.rs
@@ -9,9 +9,8 @@ use {
     },
     sea_orm::{
         entity::{ActiveValue, EntityTrait},
-        query::QueryTrait,
-        sea_query::query::OnConflict,
-        ConnectionTrait, DatabaseTransaction, DbBackend,
+        sea_query::{query::OnConflict, Alias, Condition, Expr},
+        DatabaseTransaction,
     },
     solana_sdk::pubkey::Pubkey,
 };
@@ -74,7 +73,7 @@ pub async fn save_master_edition(
         ..Default::default()
     };
 
-    let query = asset_v1_account_attachments::Entity::insert(model)
+    asset_v1_account_attachments::Entity::insert(model)
         .on_conflict(
             OnConflict::columns([asset_v1_account_attachments::Column::Id])
                 .update_columns([
@@ -82,9 +81,40 @@ pub async fn save_master_edition(
                     asset_v1_account_attachments::Column::Data,
                     asset_v1_account_attachments::Column::SlotUpdated,
                 ])
+                .action_cond_where(
+                    Condition::all()
+                        .add(
+                            Expr::tbl(
+                                Alias::new("excluded"),
+                                asset_v1_account_attachments::Column::AttachmentType,
+                            )
+                            .ne(Expr::tbl(
+                                asset_v1_account_attachments::Entity,
+                                asset_v1_account_attachments::Column::AttachmentType,
+                            )),
+                        )
+                        .add(
+                            Expr::tbl(
+                                Alias::new("excluded"),
+                                asset_v1_account_attachments::Column::Data,
+                            )
+                            .ne(Expr::tbl(
+                                asset_v1_account_attachments::Entity,
+                                asset_v1_account_attachments::Column::Data,
+                            )),
+                        )
+                        .add(
+                            Expr::tbl(
+                                asset_v1_account_attachments::Entity,
+                                asset_v1_account_attachments::Column::SlotUpdated,
+                            )
+                            .lte(slot as i64),
+                        ),
+                )
                 .to_owned(),
         )
-        .build(DbBackend::Postgres);
-    txn.execute(query).await?;
+        .exec_without_returning(txn)
+        .await
+        .map_err(|db_err| ProgramTransformerError::AssetIndexError(db_err.to_string()))?;
     Ok(())
 }

--- a/program_transformers/src/token_metadata/v1_asset.rs
+++ b/program_transformers/src/token_metadata/v1_asset.rs
@@ -21,9 +21,9 @@ use {
     },
     sea_orm::{
         entity::{ActiveValue, EntityTrait},
-        query::{JsonValue, QueryTrait},
-        sea_query::query::OnConflict,
-        ConnectionTrait, DbBackend, Statement, TransactionTrait,
+        query::JsonValue,
+        sea_query::{query::OnConflict, Alias, Expr},
+        Condition, ConnectionTrait, Statement, TransactionTrait,
     },
     solana_sdk::pubkey,
     tracing::warn,
@@ -41,18 +41,24 @@ pub async fn burn_v1_asset<T: ConnectionTrait + TransactionTrait>(
         burnt: ActiveValue::Set(true),
         ..Default::default()
     };
-    let mut query = asset::Entity::insert(model)
+
+    asset::Entity::insert(model)
         .on_conflict(
             OnConflict::columns([asset::Column::Id])
                 .update_columns([asset::Column::SlotUpdated, asset::Column::Burnt])
+                .action_cond_where(
+                    Condition::all()
+                        .add(
+                            Expr::tbl(Alias::new("excluded"), asset::Column::Burnt)
+                                .ne(Expr::tbl(asset::Entity, asset::Column::Burnt)),
+                        )
+                        .add(Expr::tbl(asset::Entity, asset::Column::SlotUpdated).lte(slot_i)),
+                )
                 .to_owned(),
         )
-        .build(DbBackend::Postgres);
-    query.sql = format!(
-        "{} WHERE excluded.slot_updated > asset.slot_updated",
-        query.sql
-    );
-    conn.execute(query).await?;
+        .exec_without_returning(conn)
+        .await?;
+
     Ok(())
 }
 
@@ -134,7 +140,7 @@ pub async fn save_v1_asset<T: ConnectionTrait + TransactionTrait>(
     txn.execute(set_lock_timeout_stmt).await?;
     txn.execute(set_local_app_name_stmt).await?;
 
-    let mut query = asset_data::Entity::insert(asset_data_model)
+    asset_data::Entity::insert(asset_data_model)
         .on_conflict(
             OnConflict::columns([asset_data::Column::Id])
                 .update_columns([
@@ -148,14 +154,93 @@ pub async fn save_v1_asset<T: ConnectionTrait + TransactionTrait>(
                     asset_data::Column::RawSymbol,
                     asset_data::Column::BaseInfoSeq,
                 ])
+                .action_cond_where(
+                    Condition::all()
+                        .add(
+                            Condition::any()
+                                .add(
+                                    Expr::tbl(
+                                        Alias::new("excluded"),
+                                        asset_data::Column::ChainDataMutability,
+                                    )
+                                    .ne(Expr::tbl(
+                                        asset_data::Entity,
+                                        asset_data::Column::ChainDataMutability,
+                                    )),
+                                )
+                                .add(
+                                    Expr::tbl(
+                                        Alias::new("excluded"),
+                                        asset_data::Column::ChainData,
+                                    )
+                                    .ne(Expr::tbl(
+                                        asset_data::Entity,
+                                        asset_data::Column::ChainData,
+                                    )),
+                                )
+                                .add(
+                                    Expr::tbl(
+                                        Alias::new("excluded"),
+                                        asset_data::Column::MetadataUrl,
+                                    )
+                                    .ne(Expr::tbl(
+                                        asset_data::Entity,
+                                        asset_data::Column::MetadataUrl,
+                                    )),
+                                )
+                                .add(
+                                    Expr::tbl(
+                                        Alias::new("excluded"),
+                                        asset_data::Column::MetadataMutability,
+                                    )
+                                    .ne(Expr::tbl(
+                                        asset_data::Entity,
+                                        asset_data::Column::MetadataMutability,
+                                    )),
+                                )
+                                .add(
+                                    Expr::tbl(Alias::new("excluded"), asset_data::Column::Reindex)
+                                        .ne(Expr::tbl(
+                                            asset_data::Entity,
+                                            asset_data::Column::Reindex,
+                                        )),
+                                )
+                                .add(
+                                    Expr::tbl(Alias::new("excluded"), asset_data::Column::RawName)
+                                        .ne(Expr::tbl(
+                                            asset_data::Entity,
+                                            asset_data::Column::RawName,
+                                        )),
+                                )
+                                .add(
+                                    Expr::tbl(
+                                        Alias::new("excluded"),
+                                        asset_data::Column::RawSymbol,
+                                    )
+                                    .ne(Expr::tbl(
+                                        asset_data::Entity,
+                                        asset_data::Column::RawSymbol,
+                                    )),
+                                )
+                                .add(
+                                    Expr::tbl(
+                                        Alias::new("excluded"),
+                                        asset_data::Column::BaseInfoSeq,
+                                    )
+                                    .ne(Expr::tbl(
+                                        asset_data::Entity,
+                                        asset_data::Column::BaseInfoSeq,
+                                    )),
+                                ),
+                        )
+                        .add(
+                            Expr::tbl(asset_data::Entity, asset_data::Column::SlotUpdated)
+                                .lte(slot_i),
+                        ),
+                )
                 .to_owned(),
         )
-        .build(DbBackend::Postgres);
-    query.sql = format!(
-        "{} WHERE excluded.slot_updated > asset_data.slot_updated",
-        query.sql
-    );
-    txn.execute(query)
+        .exec_without_returning(&txn)
         .await
         .map_err(|db_err| ProgramTransformerError::AssetIndexError(db_err.to_string()))?;
 
@@ -184,14 +269,14 @@ pub async fn save_v1_asset<T: ConnectionTrait + TransactionTrait>(
         attachment_type: ActiveValue::Set(V1AccountAttachments::MasterEditionV2),
         ..Default::default()
     };
-    let query = asset_v1_account_attachments::Entity::insert(attachment)
+
+    asset_v1_account_attachments::Entity::insert(attachment)
         .on_conflict(
             OnConflict::columns([asset_v1_account_attachments::Column::Id])
                 .do_nothing()
                 .to_owned(),
         )
-        .build(DbBackend::Postgres);
-    txn.execute(query)
+        .exec_without_returning(&txn)
         .await
         .map_err(|db_err| ProgramTransformerError::AssetIndexError(db_err.to_string()))?;
 
@@ -202,21 +287,34 @@ pub async fn save_v1_asset<T: ConnectionTrait + TransactionTrait>(
         slot_updated: ActiveValue::Set(slot_i),
         ..Default::default()
     };
-    let mut query = asset_authority::Entity::insert(model)
+
+    asset_authority::Entity::insert(model)
         .on_conflict(
-            OnConflict::columns([asset_authority::Column::AssetId])
+            OnConflict::column(asset_authority::Column::AssetId)
                 .update_columns([
                     asset_authority::Column::Authority,
                     asset_authority::Column::SlotUpdated,
                 ])
+                .action_cond_where(
+                    Condition::all()
+                        .add(
+                            Expr::tbl(Alias::new("excluded"), asset_authority::Column::Authority)
+                                .ne(Expr::tbl(
+                                    asset_authority::Entity,
+                                    asset_authority::Column::Authority,
+                                )),
+                        )
+                        .add(
+                            Expr::tbl(
+                                asset_authority::Entity,
+                                asset_authority::Column::SlotUpdated,
+                            )
+                            .lte(slot_i),
+                        ),
+                )
                 .to_owned(),
         )
-        .build(DbBackend::Postgres);
-    query.sql = format!(
-        "{} WHERE excluded.slot_updated > asset_authority.slot_updated AND excluded.authority != asset_authority.authority",
-        query.sql
-    );
-    txn.execute(query)
+        .exec_without_returning(&txn)
         .await
         .map_err(|db_err| ProgramTransformerError::AssetIndexError(db_err.to_string()))?;
 
@@ -230,7 +328,8 @@ pub async fn save_v1_asset<T: ConnectionTrait + TransactionTrait>(
             slot_updated: ActiveValue::Set(Some(slot_i)),
             ..Default::default()
         };
-        let mut query = asset_grouping::Entity::insert(model)
+
+        asset_grouping::Entity::insert(model)
             .on_conflict(
                 OnConflict::columns([
                     asset_grouping::Column::AssetId,
@@ -240,16 +339,39 @@ pub async fn save_v1_asset<T: ConnectionTrait + TransactionTrait>(
                     asset_grouping::Column::GroupValue,
                     asset_grouping::Column::Verified,
                     asset_grouping::Column::SlotUpdated,
-                    asset_grouping::Column::GroupInfoSeq,
                 ])
+                .action_cond_where(
+                    Condition::all()
+                        .add(
+                            Condition::any().add(
+                                Expr::tbl(
+                                    Alias::new("excluded"),
+                                    asset_grouping::Column::GroupValue,
+                                )
+                                .ne(Expr::tbl(
+                                    asset_grouping::Entity,
+                                    asset_grouping::Column::GroupValue,
+                                ))
+                                .add(
+                                    Expr::tbl(
+                                        Alias::new("excluded"),
+                                        asset_grouping::Column::Verified,
+                                    )
+                                    .ne(Expr::tbl(
+                                        asset_grouping::Entity,
+                                        asset_grouping::Column::Verified,
+                                    )),
+                                ),
+                            ),
+                        )
+                        .add(
+                            Expr::tbl(asset_grouping::Entity, asset_grouping::Column::SlotUpdated)
+                                .lte(slot_i),
+                        ),
+                )
                 .to_owned(),
             )
-            .build(DbBackend::Postgres);
-        query.sql = format!(
-            "{} WHERE excluded.slot_updated > asset_grouping.slot_updated",
-            query.sql
-        );
-        txn.execute(query)
+            .exec_without_returning(&txn)
             .await
             .map_err(|db_err| ProgramTransformerError::AssetIndexError(db_err.to_string()))?;
     }
@@ -272,7 +394,7 @@ pub async fn save_v1_asset<T: ConnectionTrait + TransactionTrait>(
         .collect::<Vec<_>>();
 
     if !creators.is_empty() {
-        let mut query = asset_creators::Entity::insert_many(creators)
+        asset_creators::Entity::insert_many(creators)
             .on_conflict(
                 OnConflict::columns([
                     asset_creators::Column::AssetId,
@@ -282,17 +404,51 @@ pub async fn save_v1_asset<T: ConnectionTrait + TransactionTrait>(
                     asset_creators::Column::Creator,
                     asset_creators::Column::Share,
                     asset_creators::Column::Verified,
-                    asset_creators::Column::Seq,
                     asset_creators::Column::SlotUpdated,
                 ])
+                .action_cond_where(
+                    Condition::all()
+                        .add(
+                            Condition::any()
+                                .add(
+                                    Expr::tbl(
+                                        Alias::new("excluded"),
+                                        asset_creators::Column::Creator,
+                                    )
+                                    .ne(Expr::tbl(
+                                        asset_creators::Entity,
+                                        asset_creators::Column::Creator,
+                                    )),
+                                )
+                                .add(
+                                    Expr::tbl(
+                                        Alias::new("excluded"),
+                                        asset_creators::Column::Share,
+                                    )
+                                    .ne(Expr::tbl(
+                                        asset_creators::Entity,
+                                        asset_creators::Column::Share,
+                                    )),
+                                )
+                                .add(
+                                    Expr::tbl(
+                                        Alias::new("excluded"),
+                                        asset_creators::Column::Verified,
+                                    )
+                                    .ne(Expr::tbl(
+                                        asset_creators::Entity,
+                                        asset_creators::Column::Verified,
+                                    )),
+                                ),
+                        )
+                        .add(
+                            Expr::tbl(asset_creators::Entity, asset_creators::Column::SlotUpdated)
+                                .lte(slot_i),
+                        ),
+                )
                 .to_owned(),
             )
-            .build(DbBackend::Postgres);
-        query.sql = format!(
-                "{} WHERE excluded.slot_updated >= asset_creators.slot_updated OR asset_creators.slot_updated is NULL",
-                query.sql
-            );
-        txn.execute(query)
+            .exec_without_returning(&txn)
             .await
             .map_err(|db_err| ProgramTransformerError::AssetIndexError(db_err.to_string()))?;
     }


### PR DESCRIPTION
Context

While observing postgres logs I saw the same record (a collection mint) being updated over and over again from be referenced in bubblegum mint instructions. The fields aren't different on the asset but its slot is updating. When the update happens the row is locked because it has to update indexes. This causes other processes to wait to do the same thing causing a major bottleneck.

Change

Expand the where clause on the update to only update the record when the slot is larger and any of the fields have changed.
