### PR TITLE
Stricter Lock Timeouts

### DIFF
--- a/program_transformers/src/bubblegum/mint_v1.rs
+++ b/program_transformers/src/bubblegum/mint_v1.rs
@@ -24,7 +24,7 @@ use {
         },
         json::ChainDataV1,
     },
-    sea_orm::{ConnectionTrait, TransactionTrait},
+    sea_orm::{ConnectionTrait, Statement, TransactionTrait},
     tracing::warn,
 };
 
@@ -54,6 +54,20 @@ where
         // an error and this function returns it using the `?` operator), then the transaction is
         // automatically rolled back.
         let multi_txn = txn.begin().await?;
+
+        let set_lock_timeout = "SET LOCAL lock_timeout = '2s';";
+        let set_local_app_name =
+            "SET LOCAL application_name = 'das::program_transformers::bubblegum::mint_v1';";
+        let set_lock_timeout_stmt = Statement::from_string(
+            multi_txn.get_database_backend(),
+            set_lock_timeout.to_string(),
+        );
+        let set_local_app_name_stmt = Statement::from_string(
+            multi_txn.get_database_backend(),
+            set_local_app_name.to_string(),
+        );
+        multi_txn.execute(set_lock_timeout_stmt).await?;
+        multi_txn.execute(set_local_app_name_stmt).await?;
 
         let seq =
             save_changelog_event(cl, bundle.slot, bundle.txn_id, &multi_txn, instruction).await?;

--- a/program_transformers/src/bubblegum/transfer.rs
+++ b/program_transformers/src/bubblegum/transfer.rs
@@ -10,7 +10,7 @@ use {
         instruction::InstructionBundle,
         programs::bubblegum::{BubblegumInstruction, LeafSchema},
     },
-    sea_orm::{ConnectionTrait, TransactionTrait},
+    sea_orm::{ConnectionTrait, Statement, TransactionTrait},
 };
 
 pub async fn transfer<'c, T>(
@@ -27,6 +27,20 @@ where
         // an error and this function returns it using the `?` operator), then the transaction is
         // automatically rolled back.
         let multi_txn = txn.begin().await?;
+
+        let set_lock_timeout = "SET LOCAL lock_timeout = '1s';";
+        let set_local_app_name =
+            "SET LOCAL application_name = 'das::program_transformers::bubblegum::transfer';";
+        let set_lock_timeout_stmt = Statement::from_string(
+            multi_txn.get_database_backend(),
+            set_lock_timeout.to_string(),
+        );
+        let set_local_app_name_stmt = Statement::from_string(
+            multi_txn.get_database_backend(),
+            set_local_app_name.to_string(),
+        );
+        multi_txn.execute(set_lock_timeout_stmt).await?;
+        multi_txn.execute(set_local_app_name_stmt).await?;
 
         let seq =
             save_changelog_event(cl, bundle.slot, bundle.txn_id, &multi_txn, instruction).await?;

--- a/program_transformers/src/mpl_core_program/v1_asset.rs
+++ b/program_transformers/src/mpl_core_program/v1_asset.rs
@@ -107,7 +107,7 @@ pub async fn save_v1_asset<T: ConnectionTrait + TransactionTrait>(
 
     let txn = conn.begin().await?;
 
-    let set_lock_timeout = "SET LOCAL lock_timeout = '5s';";
+    let set_lock_timeout = "SET LOCAL lock_timeout = '1s';";
     let set_local_app_name =
         "SET LOCAL application_name = 'das::program_transformers::mpl_core_program::v1_asset';";
     let set_lock_timeout_stmt =

--- a/program_transformers/src/token/mod.rs
+++ b/program_transformers/src/token/mod.rs
@@ -13,7 +13,7 @@ use {
         entity::ActiveValue,
         sea_query::query::OnConflict,
         sea_query::{Alias, Condition, Expr},
-        DatabaseConnection, EntityTrait, TransactionTrait,
+        ConnectionTrait, DatabaseConnection, EntityTrait, Statement, TransactionTrait,
     },
     solana_sdk::program_option::COption,
     spl_token::state::AccountState,
@@ -50,6 +50,16 @@ pub async fn handle_token_program_account<'a, 'b>(
             };
 
             let txn = db.begin().await?;
+
+            let set_lock_timeout = "SET LOCAL lock_timeout = '100ms';";
+            let set_local_app_name =
+                "SET LOCAL application_name = 'das::program_transformers::token::token_account';";
+            let set_lock_timeout_stmt =
+                Statement::from_string(txn.get_database_backend(), set_lock_timeout.to_string());
+            let set_local_app_name_stmt =
+                Statement::from_string(txn.get_database_backend(), set_local_app_name.to_string());
+            txn.execute(set_lock_timeout_stmt).await?;
+            txn.execute(set_local_app_name_stmt).await?;
 
             token_accounts::Entity::insert(model)
                 .on_conflict(
@@ -205,6 +215,16 @@ pub async fn handle_token_program_account<'a, 'b>(
             };
 
             let txn = db.begin().await?;
+
+            let set_lock_timeout = "SET LOCAL lock_timeout = '100ms';";
+            let set_local_app_name =
+                "SET LOCAL application_name = 'das::program_transformers::token::mint';";
+            let set_lock_timeout_stmt =
+                Statement::from_string(txn.get_database_backend(), set_lock_timeout.to_string());
+            let set_local_app_name_stmt =
+                Statement::from_string(txn.get_database_backend(), set_local_app_name.to_string());
+            txn.execute(set_lock_timeout_stmt).await?;
+            txn.execute(set_local_app_name_stmt).await?;
 
             tokens::Entity::insert(model)
                 .on_conflict(

--- a/program_transformers/src/token_metadata/v1_asset.rs
+++ b/program_transformers/src/token_metadata/v1_asset.rs
@@ -130,7 +130,7 @@ pub async fn save_v1_asset<T: ConnectionTrait + TransactionTrait>(
     };
     let txn = conn.begin().await?;
 
-    let set_lock_timeout = "SET LOCAL lock_timeout = '5s';";
+    let set_lock_timeout = "SET LOCAL lock_timeout = '1s';";
     let set_local_app_name =
         "SET LOCAL application_name = 'das::program_transformers::token_metadata::v1_asset';";
     let set_lock_timeout_stmt =


### PR DESCRIPTION
## Changes
- asset indexing timeout from 5s to 1s
- All token account have timeout of 100ms
- Bubblegum mint_v1 to 2s