### PR TITLE
When searching for fungible-asset using searchAssets for particular owner_address, empty owner field in the response bug fixed

### DIFF
--- a/digital_asset_types/src/dao/scopes/asset.rs
+++ b/digital_asset_types/src/dao/scopes/asset.rs
@@ -314,8 +314,9 @@ pub async fn get_related_for_assets(
         }
     }
 
-    // While using getAssetByOwner or searchAssets with owner_address, for fungible_assets held by the particular owner
-    // the owner feild was coming as empty, instead in the place of owner we should show the owner of that token-account
+    // When using getAssetByOwner or searchAssets with an owner_address to retrieve fungible assets, the 'owner' field was previously returned as empty.
+    // Instead of an empty value, we should now display the actual owner of the token account associated with the asset.
+
     if show_owner_for_fungible {
         let token_account_data: Vec<token_accounts::Model> = token_accounts::Entity::find()
             .filter(token_accounts::Column::Mint.is_in(asset_ids))

--- a/digital_asset_types/src/dapi/search_assets.rs
+++ b/digital_asset_types/src/dapi/search_assets.rs
@@ -24,6 +24,7 @@ pub async fn search_assets(
         &pagination,
         page_options.limit,
         options.show_unverified_collections,
+        true,
     )
     .await?;
     Ok(build_asset_response(

--- a/integration_tests/tests/integration_tests/snapshots/integration_tests__token_type_test__search_asset_with_token_type_fungible.snap
+++ b/integration_tests/tests/integration_tests/snapshots/integration_tests__token_type_test__search_asset_with_token_type_fungible.snap
@@ -55,7 +55,7 @@ snapshot_kind: text
         "delegated": false,
         "delegate": null,
         "ownership_model": "token",
-        "owner": ""
+        "owner": "2oerfxddTpK5hWAmCMYB6fr9WvNrjEH54CHCWK8sAq7g"
       },
       "mutable": true,
       "burnt": false


### PR DESCRIPTION
Problem Description

- [x] When searching for fungible asset using searchAsset for particular owner_address, empty owner field in the response bug fixed