### PR TITLE
revert metaplex/plerkle-validator image to from ..79 to ..75

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -107,7 +107,7 @@ services:
     volumes:
       - ./db-data/:/var/lib/postgresql/data/:z
   solana:
-    image: ghcr.io/metaplex-foundation/plerkle-test-validator:v1.9.0-1.79.0-v1.18.11
+    image: ghcr.io/metaplex-foundation/plerkle-test-validator:v1.9.0-1.75.0-v1.18.11
     volumes:
       - ./programs:/so/:ro
       - ./ledger:/config:rw


### PR DESCRIPTION
while updating rust version to 1.79 this was introduced , reverting this to ..75