### PR TITLE
add redis pipes for processing metadata download

### DIFF
--- a/grpc-ingest/config-ingester.example.yml
+++ b/grpc-ingest/config-ingester.example.yml
@@ -64,7 +64,7 @@ download_metadata_publish:
   # maximum number of concurrent tasks for processing.
   max_concurrency: 10
   # stream name
-  stream_name: METADATA_JSON
+  stream_name: METADATA_JSONS
   # stream max length
   stream_maxlen: 100_000_000
   # number of pipelines that can be processed concurrently

--- a/grpc-ingest/config-ingester.example.yml
+++ b/grpc-ingest/config-ingester.example.yml
@@ -59,3 +59,16 @@ download_metadata:
   request_timeout: 5_000
   stream:
     name: METADATA_JSON
+
+download_metadata_publish:
+  # maximum number of concurrent tasks for processing.
+  max_concurrency: 10
+  # stream name
+  stream_name: METADATA_JSON
+  # stream max length
+  stream_maxlen: 100_000_000
+  # number of pipelines that can be processed concurrently
+  pipeline_count: 10
+  # pipeline max idle time in milliseconds
+  pipeline_max_idle_ms: 150
+

--- a/grpc-ingest/src/config.rs
+++ b/grpc-ingest/src/config.rs
@@ -269,7 +269,7 @@ pub struct ConfigDownloadMetadataPublish {
 
 impl ConfigDownloadMetadataPublish {
     pub fn default_stream_name() -> String {
-        "METADATA_JSON".to_owned()
+        "METADATA_JSONS".to_owned()
     }
 
     pub const fn default_max_concurrency() -> usize {

--- a/grpc-ingest/src/config.rs
+++ b/grpc-ingest/src/config.rs
@@ -254,6 +254,17 @@ pub struct ConfigDownloadMetadataPublish {
         deserialize_with = "deserialize_usize_str"
     )]
     pub stream_maxlen: usize,
+    #[serde(
+        default = "ConfigDownloadMetadataPublish::default_pipeline_count",
+        deserialize_with = "deserialize_usize_str"
+    )]
+    pub pipeline_count: usize,
+
+    #[serde(
+        default = "ConfigDownloadMetadataPublish::default_pipeline_max_idle",
+        deserialize_with = "deserialize_duration_str"
+    )]
+    pub pipeline_max_idle: Duration,
 }
 
 impl ConfigDownloadMetadataPublish {
@@ -267,6 +278,14 @@ impl ConfigDownloadMetadataPublish {
 
     pub const fn default_stream_maxlen() -> usize {
         10_000_000
+    }
+
+    pub const fn default_pipeline_count() -> usize {
+        10
+    }
+
+    pub const fn default_pipeline_max_idle() -> Duration {
+        Duration::from_millis(150)
     }
 }
 


### PR DESCRIPTION
Use redis pipes to write x_add commands of metadata_json download data  and flush the pipe at regular intervals