### PR TITLE
Script for debugging asset not found

### DIFF
--- a/dash
+++ b/dash
@@ -1,0 +1,114 @@
+#!/bin/bash
+
+# Function to read lines from standard input
+dash::read-lines() {
+  local line
+  while IFS= read -r line; do
+    echo "$line"
+  done
+}
+
+# Function to parallelize command execution
+dash::parallelize() {
+  local function_name="$1"
+  shift
+  local ids=()
+  local additional_args=()
+
+  # Separate ids and additional arguments
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+    --)
+      shift
+      break
+      ;; # Use '--' as a delimiter between ids and additional arguments
+    *) ids+=("$1") ;;
+    esac
+    shift
+  done
+  additional_args=("$@")
+
+  # Export the specified function
+  export -f $function_name
+
+  # Execute the command in parallel
+  printf "%s\n" "${ids[@]}" | xargs -P 20 -n 1 -I {} bash -c "$function_name \"{}\" \"\$@\"" _ "${additional_args[@]}"
+}
+
+command::index-nft() {
+  local id="$1"
+  local endpoint="$2"
+  local database="$3"
+
+  RUST_LOG=none ./target/debug/das-ops account nft $1 --solana-rpc-url $2 --database-url $3
+
+  echo "$id"
+}
+
+# Function to get asset
+command::get-asset() {
+  local id="$1"
+  local endpoint="$2"
+
+  response=$(curl -s $endpoint -H 'content-type: application/json' -X POST -d '{
+    "jsonrpc": "2.0",
+    "id": "123",
+    "method": "getAsset",
+    "params": {
+      "id": "'"$id"'"
+    }
+  }')
+
+  error_code=$(echo "$response" | jq -r '.error.code // empty')
+
+  if [ -n "$error_code" ]; then
+    echo "$id"
+  fi
+}
+
+# Check if a command is provided
+if [ "$1" != "asset" ]; then
+  echo "Usage: $0 asset <command> -e <endpoint> [-d <database>]"
+  exit 1
+fi
+
+# Shift past the 'asset' keyword
+shift
+
+# Capture the command to run
+command="$1"
+shift
+
+# Parse options
+while getopts "e:d:" opt; do
+  case $opt in
+  e) endpoint="$OPTARG" ;;
+  d) database="$OPTARG" ;;
+  *)
+    echo "Invalid option: -$OPTARG" >&2
+    exit 1
+    ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+# Read lines from standard input and process them
+ids=($(dash::read-lines))
+
+# Determine which command to run
+case "$command" in
+index)
+  if [ -z "$database" ]; then
+    echo "Database URL is required for indexing."
+    exit 1
+  fi
+  dash::parallelize command::index-nft "${ids[@]}" -- "$endpoint" "$database"
+  ;;
+get)
+  dash::parallelize command::get-asset "${ids[@]}" -- "$endpoint"
+  ;;
+*)
+  echo "Unknown command: $command"
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
## Changes
- Script to replicate and evaluate Asset not found errors returned from api logs.

## Usage

```bash
cat id-list.txt | ./dash asset index-e {rcp-endpoint} -d {database-url}

cat id-list.txt | ./dash asset get -e {rcp-endpoint}
```

## Warning
Script expects debug build of ops cli and script should be ran from the root of directory of the repository