### PR TITLE
`feat:` Add over-fetch for small gaps on backfilling

### DIFF
--- a/bubblegum/src/backfill/gap.rs
+++ b/bubblegum/src/backfill/gap.rs
@@ -27,7 +27,7 @@ pub struct OverfetchArgs {
 
     /// Lookup used with LEAD in the SQL query to get the overfetch tx
     #[arg(long, env, default_value = "10")]
-    pub overfetch_lookup_limit: i64,
+    pub overfetch_lookup_limit: i32,
 }
 
 const TREE_GAP_SQL: &str = r#"
@@ -38,7 +38,7 @@ WITH sequenced_data AS (
         LEAD(seq) OVER (ORDER BY seq ASC) AS next_seq,
         tx AS current_tx,
         LEAD(tx) OVER (ORDER BY seq ASC) AS next_tx,
-        LEAD(tx, $2) OVER (ORDER BY seq ASC) AS overfetch_tx,
+        LEAD(tx, $2) OVER (ORDER BY seq ASC) AS overfetch_tx
     FROM
         cl_audits_v2
     WHERE
@@ -85,14 +85,14 @@ impl TreeGapModel {
     pub async fn find(
         conn: &DatabaseConnection,
         tree: Pubkey,
-        overfetch_lookup_limit: i64,
+        overfetch_lookup_limit: i32,
     ) -> Result<Vec<Self>, ErrorKind> {
         let statement = Statement::from_sql_and_values(
             DbBackend::Postgres,
             TREE_GAP_SQL,
             vec![
                 Value::Bytes(Some(Box::new(tree.as_ref().to_vec()))),
-                Value::BigInt(Some(overfetch_lookup_limit)),
+                Value::Int(Some(overfetch_lookup_limit)),
             ],
         );
 

--- a/bubblegum/src/backfill/gap.rs
+++ b/bubblegum/src/backfill/gap.rs
@@ -1,6 +1,6 @@
 use crate::{error::ErrorKind, Rpc};
 use anyhow::Result;
-use clap::Args;
+use clap::{Args, Parser};
 use sea_orm::{DatabaseConnection, DbBackend, FromQueryResult, Statement, Value};
 use solana_client::rpc_response::RpcConfirmedTransactionStatusWithSignature;
 use solana_sdk::{pubkey::Pubkey, signature::Signature};
@@ -9,11 +9,25 @@ use tokio::sync::mpsc::Sender;
 
 const GET_SIGNATURES_FOR_ADDRESS_LIMIT: usize = 1000;
 
+/// Below this limit, the gap will be processed using `GAP_LIMIT_RPC` as limit in the RPC call
+const GAP_LIMIT: i64 = 10;
+
 #[derive(Debug, Clone, Args)]
 pub struct ConfigBackfiller {
     /// Solana RPC URL
     #[arg(long, env)]
     pub solana_rpc_url: String,
+}
+
+#[derive(Debug, Parser, Clone)]
+pub struct OverfetchArgs {
+    /// Signatures limit for the RPC call
+    #[arg(long, env, default_value = "20")]
+    pub gap_limit_rpc: usize,
+
+    /// Lookup used with LEAD in the SQL query to get the overfetch tx
+    #[arg(long, env, default_value = "10")]
+    pub overfetch_lookup_limit: i64,
 }
 
 const TREE_GAP_SQL: &str = r#"
@@ -23,7 +37,8 @@ WITH sequenced_data AS (
         seq,
         LEAD(seq) OVER (ORDER BY seq ASC) AS next_seq,
         tx AS current_tx,
-        LEAD(tx) OVER (ORDER BY seq ASC) AS next_tx
+        LEAD(tx) OVER (ORDER BY seq ASC) AS next_tx,
+        LEAD(tx, $2) OVER (ORDER BY seq ASC) AS overfetch_tx,
     FROM
         cl_audits_v2
     WHERE
@@ -35,7 +50,8 @@ gaps AS (
         seq AS gap_start_seq,
         next_seq AS gap_end_seq,
         current_tx AS lower_bound_tx,
-        next_tx AS upper_bound_tx
+        next_tx AS upper_bound_tx,
+        overfetch_tx
     FROM
         sequenced_data
     WHERE
@@ -47,7 +63,8 @@ SELECT
     gap_start_seq,
     gap_end_seq,
     lower_bound_tx,
-    upper_bound_tx
+    upper_bound_tx,
+    overfetch_tx
 FROM
     gaps
 ORDER BY
@@ -61,14 +78,22 @@ pub struct TreeGapModel {
     pub gap_end_seq: i64,
     pub lower_bound_tx: Vec<u8>,
     pub upper_bound_tx: Vec<u8>,
+    pub overfetch_tx: Vec<u8>,
 }
 
 impl TreeGapModel {
-    pub async fn find(conn: &DatabaseConnection, tree: Pubkey) -> Result<Vec<Self>, ErrorKind> {
+    pub async fn find(
+        conn: &DatabaseConnection,
+        tree: Pubkey,
+        overfetch_lookup_limit: i64,
+    ) -> Result<Vec<Self>, ErrorKind> {
         let statement = Statement::from_sql_and_values(
             DbBackend::Postgres,
             TREE_GAP_SQL,
-            vec![Value::Bytes(Some(Box::new(tree.as_ref().to_vec())))],
+            vec![
+                Value::Bytes(Some(Box::new(tree.as_ref().to_vec()))),
+                Value::BigInt(Some(overfetch_lookup_limit)),
+            ],
         );
 
         TreeGapModel::find_by_statement(statement)
@@ -88,7 +113,16 @@ impl TryFrom<TreeGapModel> for TreeGapFill {
         let lower =
             Signature::try_from(model.lower_bound_tx).map_err(|_| ErrorKind::TryFromSignature)?;
 
-        Ok(Self::new(tree, Some(upper), Some(lower)))
+        let overfetch = if model.gap_end_seq - model.gap_start_seq < GAP_LIMIT {
+            match Signature::try_from(model.overfetch_tx) {
+                Ok(sig) => Some(sig),
+                Err(_) => None,
+            }
+        } else {
+            None
+        };
+
+        Ok(Self::new(tree, Some(upper), Some(lower), overfetch))
     }
 }
 
@@ -96,23 +130,42 @@ pub struct TreeGapFill {
     tree: Pubkey,
     before: Option<Signature>,
     until: Option<Signature>,
+    overfetch_tx: Option<Signature>,
 }
 
 impl TreeGapFill {
-    pub const fn new(tree: Pubkey, before: Option<Signature>, until: Option<Signature>) -> Self {
+    pub const fn new(
+        tree: Pubkey,
+        before: Option<Signature>,
+        until: Option<Signature>,
+        overfetch_tx: Option<Signature>,
+    ) -> Self {
         Self {
             tree,
             before,
             until,
+            overfetch_tx,
         }
     }
 
-    pub async fn crawl(&self, client: Rpc, sender: Sender<Signature>) -> Result<()> {
+    pub async fn crawl(
+        &self,
+        client: Rpc,
+        sender: Sender<Signature>,
+        overfetch_args: OverfetchArgs,
+    ) -> Result<()> {
         let mut before = self.before;
+
+        let (limit, until) = if self.overfetch_tx.is_some() {
+            before = self.overfetch_tx;
+            (Some(overfetch_args.gap_limit_rpc), None)
+        } else {
+            (None, self.until)
+        };
 
         loop {
             let sigs = client
-                .get_signatures_for_address(&self.tree, before, self.until)
+                .get_signatures_for_address(&self.tree, before, until, limit)
                 .await?;
             let sig_count = sigs.len();
 

--- a/core/src/solana_rpc.rs
+++ b/core/src/solana_rpc.rs
@@ -65,6 +65,7 @@ impl Rpc {
         pubkey: &Pubkey,
         before: Option<Signature>,
         until: Option<Signature>,
+        limit: Option<usize>,
     ) -> Result<Vec<RpcConfirmedTransactionStatusWithSignature>, ClientError> {
         (|| async {
             self.0
@@ -73,10 +74,10 @@ impl Rpc {
                     GetConfirmedSignaturesForAddress2Config {
                         before,
                         until,
+                        limit,
                         commitment: Some(CommitmentConfig {
                             commitment: CommitmentLevel::Finalized,
                         }),
-                        ..GetConfirmedSignaturesForAddress2Config::default()
                     },
                 )
                 .await


### PR DESCRIPTION
Add overfetch to fix the issue where small gaps are not filled in the backfill process due to empty `get_signatures_for_address` RPC responses