### PR TITLE
`feat` : Add cmd for purging token_accounts and mints which dont exists on chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1952,6 +1952,7 @@ version = "0.7.2"
 dependencies = [
  "anchor-client",
  "anyhow",
+ "async-trait",
  "borsh 0.10.4",
  "bs58 0.4.0",
  "cadence",
@@ -3348,8 +3349,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "borsh 0.10.4",
+ "das-core",
+ "das-ops",
  "das_api",
  "digital_asset_types",
+ "env_logger 0.10.2",
  "flatbuffers",
  "function_name",
  "futures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,7 @@ wasm-bindgen = "0.2.83"
 yellowstone-grpc-client = { git = "https://github.com/rpcpool/yellowstone-grpc.git", tag = "v1.15.1+solana.1.18.22" }                          # tag is geyser plugin
 yellowstone-grpc-proto = { git = "https://github.com/rpcpool/yellowstone-grpc.git", tag = "v1.15.1+solana.1.18.22" }                           # tag is geyser plugin
 yellowstone-grpc-tools = { git = "https://github.com/rpcpool/yellowstone-grpc.git", tag = "v1.15.1+solana.1.18.22", default-features = false } # tag is geyser plugin
+das-ops = { path = "ops" }
 
 [workspace.lints.clippy]
 clone_on_ref_ptr = "deny"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -33,10 +33,13 @@ solana-account-decoder = { workspace = true }
 solana-client = { workspace = true }
 solana-sdk = { workspace = true }
 solana-transaction-status = { workspace = true }
-sqlx = { workspace = true, fatures = ["runtime-tokio-rustls", "postgres"] }
+sqlx = { workspace = true, features = ["runtime-tokio-rustls", "postgres"] }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 url = { workspace = true }
+
+[features]
+rpc-mock = []
 
 [lints]
 workspace = true

--- a/core/src/db.rs
+++ b/core/src/db.rs
@@ -59,7 +59,7 @@ impl MockDatabasePool {
     }
 }
 
-impl DatabasePool for MockDatabasePool {
+impl DatabasePool for Arc<MockDatabasePool> {
     fn connection(&self) -> DatabaseConnection {
         DatabaseConnection::MockDatabaseConnection(Arc::clone(&self.0))
     }

--- a/core/src/db.rs
+++ b/core/src/db.rs
@@ -1,5 +1,8 @@
+use std::sync::Arc;
+
 use anyhow::Result;
 use clap::Parser;
+use sea_orm::{DatabaseConnection, MockDatabase, MockDatabaseConnection, SqlxPostgresConnector};
 use sqlx::{
     postgres::{PgConnectOptions, PgPoolOptions},
     PgPool,
@@ -35,4 +38,29 @@ pub async fn connect_db(config: &PoolArgs) -> Result<PgPool, sqlx::Error> {
         .max_connections(config.database_max_connections)
         .connect_with(options)
         .await
+}
+
+pub trait DatabasePool: Clone + Send + Sync + 'static {
+    fn connection(&self) -> DatabaseConnection;
+}
+
+impl DatabasePool for sqlx::PgPool {
+    fn connection(&self) -> DatabaseConnection {
+        SqlxPostgresConnector::from_sqlx_postgres_pool(self.clone())
+    }
+}
+
+#[derive(Clone)]
+pub struct MockDatabasePool(Arc<MockDatabaseConnection>);
+
+impl MockDatabasePool {
+    pub fn from(mock_db: MockDatabase) -> Self {
+        Self(Arc::new(MockDatabaseConnection::new(mock_db)))
+    }
+}
+
+impl DatabasePool for MockDatabasePool {
+    fn connection(&self) -> DatabaseConnection {
+        DatabaseConnection::MockDatabaseConnection(Arc::clone(&self.0))
+    }
 }

--- a/core/src/solana_rpc.rs
+++ b/core/src/solana_rpc.rs
@@ -38,6 +38,11 @@ impl Rpc {
         Rpc(Arc::new(RpcClient::new(config.solana_rpc_url.clone())))
     }
 
+    #[cfg(feature = "rpc-mock")]
+    pub fn from_mocks(mocks: solana_client::rpc_client::Mocks, rpc_result: String) -> Self {
+        Rpc(Arc::new(RpcClient::new_mock_with_mocks(rpc_result, mocks)))
+    }
+
     pub async fn get_transaction(
         &self,
         signature: &Signature,

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -33,3 +33,6 @@ spl-token = { workspace = true, features = ["no-entrypoint"] }
 sqlx = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
+das-core = { workspace = true, features = ["rpc-mock"] }
+das-ops = { workspace = true }
+env_logger = { workspace = true }

--- a/integration_tests/tests/integration_tests/main.rs
+++ b/integration_tests/tests/integration_tests/main.rs
@@ -5,6 +5,7 @@ mod fungibles_and_token_extensions_tests;
 mod general_scenario_tests;
 mod mpl_core_tests;
 mod nft_editions_tests;
+mod ops_purge;
 mod regular_nft_tests;
 mod show_collection_metadata_option_tests;
 mod show_fungible_flag_tests;

--- a/integration_tests/tests/integration_tests/ops_purge.rs
+++ b/integration_tests/tests/integration_tests/ops_purge.rs
@@ -1,12 +1,16 @@
 #[cfg(test)]
 use das_ops::purge::{start_mint_purge, start_ta_purge, Args, TOKEN_2022_PROGRAM_ID};
 use digital_asset_types::dao::{token_accounts, tokens};
-use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
+use itertools::Itertools;
+use sea_orm::{DatabaseBackend, DbBackend, MockDatabase, MockExecResult, Transaction, Value};
 use solana_account_decoder::{UiAccount, UiAccountData};
 use sqlx::types::Decimal;
-use std::{collections::HashMap, sync::Once};
+use std::{
+    collections::HashMap,
+    sync::{Arc, Once},
+};
 
-use das_core::{MockDatabasePool, Rpc};
+use das_core::{DatabasePool, MockDatabasePool, Rpc};
 
 use serial_test::serial;
 use solana_client::{
@@ -83,6 +87,13 @@ async fn test_purging_token_accounts() {
 
     let token_account_pubkeys: Vec<Pubkey> = (0..100).map(|_| Pubkey::new_unique()).collect();
 
+    let ta_bytes_vec = token_account_pubkeys
+        .iter()
+        .map(|x| x.to_bytes())
+        .collect::<Vec<[u8; 32]>>();
+
+    println!("{:?}", ta_bytes_vec);
+
     let acc_missing_index: [usize; 5] = [1, 15, 22, 40, 89];
 
     let owner_mismatch_index: [usize; 5] = [20, 29, 33, 45, 71];
@@ -101,8 +112,7 @@ async fn test_purging_token_accounts() {
         .append_query_results(vec![mock_query_res])
         .append_exec_results(vec![mock_exec_res]);
 
-    let db = MockDatabasePool::from(mock_db);
-
+    let db = Arc::new(MockDatabasePool::from(mock_db));
     let mut rpc_mock_responses = HashMap::new();
 
     let mut rpc_responses: Vec<Option<UiAccount>> = Vec::with_capacity(token_account_pubkeys.len());
@@ -138,10 +148,52 @@ async fn test_purging_token_accounts() {
             mark_deletion_worker_count: 10,
             batch_size: 10,
         },
-        db,
+        Arc::clone(&db),
         rpc,
     )
     .await;
+    assert!(res.is_ok());
+
+    let ta_deleted_pubkeys: Vec<Pubkey> = acc_missing_index
+        .iter()
+        .chain(owner_mismatch_index.iter())
+        .sorted()
+        .map(|&i| token_account_pubkeys[i])
+        .collect();
+
+    let db_txs = db.connection().into_transaction_log();
+
+    let ta_select_query =
+        r#"SELECT "token_accounts"."pubkey", "token_accounts"."mint", "token_accounts"."amount",
+ "token_accounts"."owner", "token_accounts"."frozen", "token_accounts"."close_authority",
+ "token_accounts"."delegate", "token_accounts"."delegated_amount", "token_accounts"."slot_updated",
+ "token_accounts"."token_program", "token_accounts"."extensions", "token_accounts"."pubkey"
+ FROM "token_accounts" LIMIT $1 OFFSET $2"#
+            .replace("\n", "");
+
+    let expected_db_txs = vec![
+        Transaction::from_sql_and_values(
+            DbBackend::Postgres,
+            ta_select_query.as_str(),
+            vec![10u64.into(), 0u64.into()],
+        ),
+        Transaction::from_sql_and_values(
+            DbBackend::Postgres,
+            ta_select_query.as_str(),
+            vec![10u64.into(), 10u64.into()],
+        ),
+        Transaction::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"DELETE FROM "token_accounts" WHERE "token_accounts"."pubkey" IN ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)"#,
+            ta_deleted_pubkeys
+                .iter()
+                .map(|x| Value::from(x.to_bytes().to_vec()))
+                .collect::<Vec<_>>(),
+        ),
+    ];
+
+    assert_eq!(expected_db_txs, db_txs);
+
     assert!(res.is_ok());
 }
 
@@ -156,8 +208,6 @@ async fn test_purging_mints() {
 
     let owner_mismatch_index: [usize; 5] = [20, 29, 33, 45, 71];
 
-    let asset_already_marked_burnt_index: [usize; 2] = [20, 33];
-
     let mock_query_res_1: Vec<tokens::Model> =
         mint_pubkeys.iter().map(mint_model_with_pubkey).collect();
 
@@ -166,18 +216,12 @@ async fn test_purging_mints() {
         last_insert_id: 0,
     };
 
-    let mock_exec_res_2 = MockExecResult {
-        rows_affected: (acc_missing_index.len() + owner_mismatch_index.len()
-            - asset_already_marked_burnt_index.len()) as u64,
-        last_insert_id: 0,
-    };
-
     let mock_db = MockDatabase::new(DatabaseBackend::Postgres)
         .append_query_results(vec![mock_query_res_1])
-        .append_exec_results(vec![mock_exec_res_1])
-        .append_exec_results(vec![mock_exec_res_2]);
+        .append_exec_results(vec![mock_exec_res_1.clone()])
+        .append_exec_results(vec![mock_exec_res_1]);
 
-    let db = MockDatabasePool::from(mock_db);
+    let db = Arc::new(MockDatabasePool::from(mock_db));
 
     let mut rpc_mock_responses = HashMap::new();
 
@@ -214,10 +258,59 @@ async fn test_purging_mints() {
             mark_deletion_worker_count: 10,
             batch_size: 10,
         },
-        db,
+        Arc::clone(&db),
         rpc,
     )
     .await;
+
+    let db_txs = db.connection().into_transaction_log();
+
+    let mint_deleted_pubkeys: Vec<Pubkey> = acc_missing_index
+        .iter()
+        .chain(owner_mismatch_index.iter())
+        .sorted()
+        .map(|&i| mint_pubkeys[i])
+        .collect();
+
+    let tokens_select_query = r#"SELECT "tokens"."mint", "tokens"."supply", "tokens"."decimals", "tokens"."token_program",
+ "tokens"."mint_authority", "tokens"."freeze_authority", "tokens"."close_authority", "tokens"."extension_data",
+ "tokens"."slot_updated", "tokens"."extensions", "tokens"."mint"
+ FROM "tokens" LIMIT $1 OFFSET $2"#.replace("\n", "");
+
+    let expected_db_txs = vec![
+        Transaction::from_sql_and_values(
+            DbBackend::Postgres,
+            tokens_select_query.as_str(),
+            vec![10u64.into(), 0u64.into()],
+        ),
+        Transaction::from_sql_and_values(
+            DbBackend::Postgres,
+            tokens_select_query.as_str(),
+            vec![10u64.into(), 10u64.into()],
+        ),
+        Transaction::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"DELETE FROM "tokens" WHERE "tokens"."mint" IN ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)"#,
+            mint_deleted_pubkeys
+                .iter()
+                .map(|x| Value::from(x.to_bytes().to_vec()))
+                .collect::<Vec<_>>(),
+        ),
+        Transaction::from_sql_and_values(
+            DbBackend::Postgres,
+            r#"UPDATE "asset" SET "burnt" = $1 WHERE "asset"."burnt" = $2 AND "asset"."id" IN ($3, $4, $5, $6, $7, $8, $9, $10, $11, $12)"#,
+            vec![Value::Bool(Some(true)), Value::Bool(Some(false))]
+                .into_iter()
+                .chain(
+                    mint_deleted_pubkeys
+                        .iter()
+                        .map(|x| Value::from(x.to_bytes().to_vec())),
+                )
+                .collect::<Vec<_>>(),
+        ),
+    ];
+
+    assert_eq!(expected_db_txs, db_txs);
 
     assert!(res.is_ok());
 }

--- a/integration_tests/tests/integration_tests/ops_purge.rs
+++ b/integration_tests/tests/integration_tests/ops_purge.rs
@@ -1,0 +1,223 @@
+#[cfg(test)]
+use das_ops::purge::{start_mint_purge, start_ta_purge, Args, TOKEN_2022_PROGRAM_ID};
+use digital_asset_types::dao::{token_accounts, tokens};
+use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
+use solana_account_decoder::{UiAccount, UiAccountData};
+use sqlx::types::Decimal;
+use std::{collections::HashMap, sync::Once};
+
+use das_core::{MockDatabasePool, Rpc};
+
+use serial_test::serial;
+use solana_client::{
+    rpc_request::RpcRequest,
+    rpc_response::{Response, RpcApiVersion, RpcResponseContext},
+};
+use solana_sdk::pubkey::Pubkey;
+
+static INIT: Once = Once::new();
+
+fn init_logger() {
+    INIT.call_once(|| {
+        env_logger::init();
+    });
+}
+
+fn system_program_account() -> UiAccount {
+    UiAccount {
+        lamports: 0,
+        data: UiAccountData::LegacyBinary("".to_string()),
+        owner: solana_sdk::system_program::id().to_string(),
+        executable: false,
+        rent_epoch: 0,
+        space: Some(0),
+    }
+}
+
+fn token_program_account() -> UiAccount {
+    UiAccount {
+        lamports: 100,
+        data: UiAccountData::LegacyBinary("".to_string()),
+        owner: TOKEN_2022_PROGRAM_ID.to_string(),
+        executable: false,
+        rent_epoch: 0,
+        space: Some(165),
+    }
+}
+
+fn token_account_model_with_pubkey(pubkey: &Pubkey) -> token_accounts::Model {
+    token_accounts::Model {
+        pubkey: pubkey.to_bytes().to_vec(),
+        mint: Pubkey::new_unique().to_bytes().to_vec(),
+        owner: Pubkey::new_unique().to_bytes().to_vec(),
+        delegate: None,
+        close_authority: None,
+        amount: 0,
+        frozen: false,
+        delegated_amount: 0,
+        slot_updated: 0,
+        token_program: TOKEN_2022_PROGRAM_ID.to_bytes().to_vec(),
+        extensions: None,
+    }
+}
+
+fn mint_model_with_pubkey(pubkey: &Pubkey) -> tokens::Model {
+    tokens::Model {
+        mint: pubkey.to_bytes().to_vec(),
+        decimals: 0,
+        supply: Decimal::from(0),
+        token_program: TOKEN_2022_PROGRAM_ID.to_bytes().to_vec(),
+        mint_authority: None,
+        freeze_authority: None,
+        close_authority: None,
+        slot_updated: 0,
+        extensions: None,
+        extension_data: None,
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn test_purging_token_accounts() {
+    init_logger();
+
+    let token_account_pubkeys: Vec<Pubkey> = (0..100).map(|_| Pubkey::new_unique()).collect();
+
+    let acc_missing_index: [usize; 5] = [1, 15, 22, 40, 89];
+
+    let owner_mismatch_index: [usize; 5] = [20, 29, 33, 45, 71];
+
+    let mock_query_res: Vec<token_accounts::Model> = token_account_pubkeys
+        .iter()
+        .map(token_account_model_with_pubkey)
+        .collect();
+
+    let mock_exec_res = MockExecResult {
+        rows_affected: 10,
+        last_insert_id: 0,
+    };
+
+    let mock_db = MockDatabase::new(DatabaseBackend::Postgres)
+        .append_query_results(vec![mock_query_res])
+        .append_exec_results(vec![mock_exec_res]);
+
+    let db = MockDatabasePool::from(mock_db);
+
+    let mut rpc_mock_responses = HashMap::new();
+
+    let mut rpc_responses: Vec<Option<UiAccount>> = Vec::with_capacity(token_account_pubkeys.len());
+
+    for i in 0..token_account_pubkeys.len() {
+        if acc_missing_index.contains(&i) {
+            rpc_responses.push(None);
+        } else if owner_mismatch_index.contains(&i) {
+            rpc_responses.push(Some(system_program_account()));
+        } else {
+            rpc_responses.push(Some(token_program_account()));
+        }
+    }
+
+    let json_res = serde_json::to_value(rpc_responses).unwrap();
+
+    rpc_mock_responses.insert(
+        RpcRequest::GetMultipleAccounts,
+        serde_json::json!(Response {
+            context: RpcResponseContext {
+                slot: 0,
+                api_version: Some(RpcApiVersion::default()),
+            },
+            value: json_res
+        }),
+    );
+
+    let rpc = Rpc::from_mocks(rpc_mock_responses, "succeeds".to_string());
+
+    let res = start_ta_purge(
+        Args {
+            purge_worker_count: 10,
+            mark_deletion_worker_count: 10,
+            batch_size: 10,
+        },
+        db,
+        rpc,
+    )
+    .await;
+    assert!(res.is_ok());
+}
+
+#[tokio::test]
+#[serial]
+async fn test_purging_mints() {
+    init_logger();
+
+    let mint_pubkeys: Vec<Pubkey> = (0..100).map(|_| Pubkey::new_unique()).collect();
+
+    let acc_missing_index: [usize; 5] = [1, 15, 22, 40, 89];
+
+    let owner_mismatch_index: [usize; 5] = [20, 29, 33, 45, 71];
+
+    let asset_already_marked_burnt_index: [usize; 2] = [20, 33];
+
+    let mock_query_res_1: Vec<tokens::Model> =
+        mint_pubkeys.iter().map(mint_model_with_pubkey).collect();
+
+    let mock_exec_res_1 = MockExecResult {
+        rows_affected: (acc_missing_index.len() + owner_mismatch_index.len()) as u64,
+        last_insert_id: 0,
+    };
+
+    let mock_exec_res_2 = MockExecResult {
+        rows_affected: (acc_missing_index.len() + owner_mismatch_index.len()
+            - asset_already_marked_burnt_index.len()) as u64,
+        last_insert_id: 0,
+    };
+
+    let mock_db = MockDatabase::new(DatabaseBackend::Postgres)
+        .append_query_results(vec![mock_query_res_1])
+        .append_exec_results(vec![mock_exec_res_1])
+        .append_exec_results(vec![mock_exec_res_2]);
+
+    let db = MockDatabasePool::from(mock_db);
+
+    let mut rpc_mock_responses = HashMap::new();
+
+    let mut rpc_responses: Vec<Option<UiAccount>> = Vec::with_capacity(mint_pubkeys.len());
+
+    for i in 0..mint_pubkeys.len() {
+        if acc_missing_index.contains(&i) {
+            rpc_responses.push(None);
+        } else if owner_mismatch_index.contains(&i) {
+            rpc_responses.push(Some(system_program_account()));
+        } else {
+            rpc_responses.push(Some(token_program_account()));
+        }
+    }
+
+    let json_res = serde_json::to_value(rpc_responses).unwrap();
+
+    rpc_mock_responses.insert(
+        RpcRequest::GetMultipleAccounts,
+        serde_json::json!(Response {
+            context: RpcResponseContext {
+                slot: 0,
+                api_version: Some(RpcApiVersion::default()),
+            },
+            value: json_res
+        }),
+    );
+
+    let rpc = Rpc::from_mocks(rpc_mock_responses, "succeeds".to_string());
+
+    let res = start_mint_purge(
+        Args {
+            purge_worker_count: 10,
+            mark_deletion_worker_count: 10,
+            batch_size: 10,
+        },
+        db,
+        rpc,
+    )
+    .await;
+
+    assert!(res.is_ok());
+}

--- a/ops/Cargo.toml
+++ b/ops/Cargo.toml
@@ -8,7 +8,11 @@ publish.workspace = true
 [[bin]]
 name = "das-ops"
 
+[lib]
+name = "das_ops"
+
 [dependencies]
+async-trait = { workspace = true }
 anchor-client = { workspace = true }
 anyhow = { workspace = true }
 borsh = { workspace = true }

--- a/ops/src/lib.rs
+++ b/ops/src/lib.rs
@@ -1,0 +1,5 @@
+//this file is needed to avoid rust-analyzer errors.
+pub mod account;
+pub mod bubblegum;
+pub mod metadata;
+pub mod purge;

--- a/ops/src/main.rs
+++ b/ops/src/main.rs
@@ -1,6 +1,7 @@
 mod account;
 mod bubblegum;
 mod metadata;
+mod purge;
 
 use account::{subcommand as account_subcommand, AccountCommand};
 use anyhow::Result;
@@ -22,6 +23,8 @@ enum Command {
     Account(AccountCommand),
     #[clap(name = "metadata_json")]
     MetadataJson(metadata::MetadataJsonCommand),
+    #[clap(name = "purge")]
+    Purge(purge::PurgeCommand),
 }
 
 #[tokio::main]
@@ -34,6 +37,7 @@ async fn main() -> Result<()> {
         Command::Bubblegum(subcommand) => bubblegum_subcommand(subcommand).await?,
         Command::Account(subcommand) => account_subcommand(subcommand).await?,
         Command::MetadataJson(subcommand) => metadata::subcommand(subcommand).await?,
+        Command::Purge(subcommand) => purge::subcommand(subcommand).await?,
     }
 
     Ok(())

--- a/ops/src/purge/cmd.rs
+++ b/ops/src/purge/cmd.rs
@@ -1,0 +1,38 @@
+use crate::purge::{start_mint_purge, start_ta_purge, Args as PurgeArgs};
+use anyhow::{Ok, Result};
+use clap::{Args, Subcommand};
+use das_core::{connect_db, PoolArgs, Rpc, SolanaRpcArgs};
+
+#[derive(Debug, Clone, Subcommand)]
+pub enum Commands {
+    // Purge token accounts
+    #[clap(name = "tokens")]
+    TokenAccount(PurgeArgs),
+    // Purge mints
+    #[clap(name = "mints")]
+    Mint(PurgeArgs),
+}
+
+#[derive(Debug, Clone, Args)]
+pub struct PurgeCommand {
+    /// Database configuration
+    #[clap(flatten)]
+    pub database: PoolArgs,
+    /// Solana configuration
+    #[clap(flatten)]
+    pub solana: SolanaRpcArgs,
+    /// The action to take
+    #[clap(subcommand)]
+    pub action: Commands,
+}
+
+pub async fn subcommand(subcommand: PurgeCommand) -> Result<()> {
+    let pg_pool = connect_db(&subcommand.database).await?;
+    let rpc = Rpc::from_config(&subcommand.solana);
+    match subcommand.action {
+        Commands::TokenAccount(args) => start_ta_purge(args, pg_pool, rpc).await?,
+        Commands::Mint(args) => start_mint_purge(args, pg_pool, rpc).await?,
+    };
+
+    Ok(())
+}

--- a/ops/src/purge/cmd.rs
+++ b/ops/src/purge/cmd.rs
@@ -1,4 +1,6 @@
-use crate::purge::{start_mint_purge, start_ta_purge, Args as PurgeArgs};
+use crate::purge::{
+    start_cnft_purge, start_mint_purge, start_ta_purge, Args as PurgeArgs, CnftArgs,
+};
 use anyhow::{Ok, Result};
 use clap::{Args, Subcommand};
 use das_core::{connect_db, PoolArgs, Rpc, SolanaRpcArgs};
@@ -11,6 +13,10 @@ pub enum Commands {
     // Purge mints
     #[clap(name = "mints")]
     Mint(PurgeArgs),
+    /// The 'cnft' command is used to remove from the database assets
+    ///  for which the DB contains txs that have a `TransactionError`.
+    #[clap(name = "cnft")]
+    Cnft(CnftArgs),
 }
 
 #[derive(Debug, Clone, Args)]
@@ -32,6 +38,7 @@ pub async fn subcommand(subcommand: PurgeCommand) -> Result<()> {
     match subcommand.action {
         Commands::TokenAccount(args) => start_ta_purge(args, pg_pool, rpc).await?,
         Commands::Mint(args) => start_mint_purge(args, pg_pool, rpc).await?,
+        Commands::Cnft(args) => start_cnft_purge(args, pg_pool, rpc).await?,
     };
 
     Ok(())

--- a/ops/src/purge/mod.rs
+++ b/ops/src/purge/mod.rs
@@ -1,0 +1,5 @@
+mod cmd;
+mod purger;
+
+pub use cmd::*;
+pub use purger::*;

--- a/ops/src/purge/purger.rs
+++ b/ops/src/purge/purger.rs
@@ -1,0 +1,435 @@
+use anyhow::Result;
+use borsh::BorshDeserialize;
+use clap::Parser;
+use das_core::{DatabasePool, Rpc};
+use digital_asset_types::dao::{asset, token_accounts, tokens};
+use log::{debug, error};
+use sea_orm::{
+    sea_query::Expr, ColumnTrait, EntityTrait, FromQueryResult, PaginatorTrait, QueryFilter,
+    QuerySelect,
+};
+use solana_sdk::{bs58, pubkey};
+use std::marker::{Send, Sync};
+
+use solana_sdk::pubkey::Pubkey;
+use tokio::sync::mpsc::unbounded_channel;
+use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use tokio::task::{JoinHandle, JoinSet};
+
+pub const TOKEN_PROGRAM_ID: Pubkey = pubkey!("TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA");
+
+pub const TOKEN_2022_PROGRAM_ID: Pubkey = pubkey!("TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb");
+
+// Define a trait for accessing a specific column
+trait ColumnAccess {
+    type ColumnType: ColumnTrait;
+    fn column() -> Self::ColumnType;
+}
+
+// Implement the trait for specific columns
+impl ColumnAccess for token_accounts::Entity {
+    type ColumnType = token_accounts::Column;
+
+    fn column() -> Self::ColumnType {
+        token_accounts::Column::Pubkey
+    }
+}
+
+impl ColumnAccess for tokens::Entity {
+    type ColumnType = tokens::Column;
+
+    fn column() -> Self::ColumnType {
+        tokens::Column::Mint
+    }
+}
+
+pub trait PubkeyResult: FromQueryResult + Send + Sync {
+    fn pubkey(&self) -> Vec<u8>;
+}
+
+#[derive(FromQueryResult)]
+struct TokenAccountResult {
+    pubkey: Vec<u8>,
+}
+
+#[derive(FromQueryResult)]
+struct MintResult {
+    mint: Vec<u8>,
+}
+
+impl PubkeyResult for TokenAccountResult {
+    fn pubkey(&self) -> Vec<u8> {
+        self.pubkey.clone()
+    }
+}
+
+impl PubkeyResult for MintResult {
+    fn pubkey(&self) -> Vec<u8> {
+        self.mint.clone()
+    }
+}
+
+struct Paginate<E: EntityTrait + ColumnAccess, P: DatabasePool, R: PubkeyResult> {
+    pool: Option<P>,
+    batch_size: Option<u64>,
+    sender: Option<UnboundedSender<Vec<Pubkey>>>,
+    _e_type: std::marker::PhantomData<E>,
+    _r_type: std::marker::PhantomData<R>,
+}
+
+impl<E: EntityTrait + ColumnAccess, P: DatabasePool, R: PubkeyResult> Paginate<E, P, R> {
+    pub const DEFAULT_DB_BATCH_SIZE: u64 = 100;
+
+    fn build() -> Self {
+        Self {
+            pool: None,
+            batch_size: None,
+            sender: None,
+            _e_type: std::marker::PhantomData,
+            _r_type: std::marker::PhantomData,
+        }
+    }
+
+    fn pool(mut self, pool: P) -> Self {
+        self.pool = Some(pool);
+        self
+    }
+
+    fn batch_size(mut self, batch_size: u64) -> Self {
+        self.batch_size = Some(batch_size);
+        self
+    }
+
+    fn sender(mut self, sender: UnboundedSender<Vec<Pubkey>>) -> Self {
+        self.sender = Some(sender);
+        self
+    }
+
+    fn start(self) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            let pool = self.pool.expect("Pool not set");
+            let sender = self.sender.expect("Sender not set");
+            let batch_size = self.batch_size.unwrap_or(Self::DEFAULT_DB_BATCH_SIZE);
+            let conn = pool.connection();
+
+            let mut paginator = E::find()
+                .column(E::column())
+                .into_model::<R>()
+                .paginate(&conn, batch_size);
+
+            while let Ok(Some(records)) = paginator.fetch_and_next().await {
+                let keys = records
+                    .iter()
+                    .filter_map(|row| Pubkey::try_from_slice(&row.pubkey()).ok())
+                    .collect::<Vec<Pubkey>>();
+
+                if sender.send(keys).is_err() {
+                    error!("Failed to send keys");
+                }
+            }
+        })
+    }
+}
+
+struct MarkDeletion {
+    rpc: Option<Rpc>,
+    receiver: Option<UnboundedReceiver<Vec<Pubkey>>>,
+    sender: Option<UnboundedSender<Vec<Pubkey>>>,
+    concurrency: Option<usize>,
+}
+
+impl MarkDeletion {
+    pub const DEFAULT_CONCURRENCY: usize = 10;
+
+    pub const MAX_GET_MULTIPLE_ACCOUNTS: usize = 100;
+
+    fn build() -> Self {
+        Self {
+            rpc: None,
+            receiver: None,
+            sender: None,
+            concurrency: None,
+        }
+    }
+
+    fn rpc(mut self, rpc: Rpc) -> Self {
+        self.rpc = Some(rpc);
+        self
+    }
+
+    fn receiver(mut self, receiver: UnboundedReceiver<Vec<Pubkey>>) -> Self {
+        self.receiver = Some(receiver);
+        self
+    }
+
+    fn sender(mut self, sender: UnboundedSender<Vec<Pubkey>>) -> Self {
+        self.sender = Some(sender);
+        self
+    }
+
+    fn concurrency(mut self, concurrency: usize) -> Self {
+        self.concurrency = Some(concurrency);
+        self
+    }
+
+    fn start(self) -> JoinHandle<()> {
+        let rpc = self.rpc.expect("Rpc not set");
+        let mut receiver = self.receiver.expect("Receiver not set");
+        let sender = self.sender.expect("Sender not set");
+        let concurrency = self.concurrency.unwrap_or(Self::DEFAULT_CONCURRENCY);
+
+        tokio::spawn(async move {
+            let mut tasks = JoinSet::new();
+            while let Some(keys) = receiver.recv().await {
+                let rpc = rpc.clone();
+                let sender = sender.clone();
+                if tasks.len() >= concurrency {
+                    tasks.join_next().await;
+                }
+
+                tasks.spawn(async move {
+                    for chunk in keys.chunks(Self::MAX_GET_MULTIPLE_ACCOUNTS) {
+                        let chunk = chunk.to_vec();
+                        debug!("chunk len: {}", chunk.len());
+
+                        if let Ok(accounts) = rpc.get_multiple_accounts(&chunk).await {
+                            let mut remove = Vec::new();
+
+                            for (key, acc) in chunk.iter().zip(accounts.iter()) {
+                                match acc {
+                                    Some(acc) => {
+                                        if acc.owner.ne(&TOKEN_PROGRAM_ID)
+                                            && acc.owner.ne(&TOKEN_2022_PROGRAM_ID)
+                                        {
+                                            remove.push(*key);
+                                        }
+                                    }
+                                    None => {
+                                        remove.push(*key);
+                                    }
+                                }
+                            }
+                            if remove.is_empty() {
+                                continue;
+                            }
+                            debug!("entries to purge: {:?}", remove.len());
+                            if sender.send(remove).is_err() {
+                                error!("Failed to send marked keys");
+                            }
+                        }
+                    }
+                });
+            }
+            while tasks.join_next().await.is_some() {}
+        })
+    }
+}
+
+trait Purge {
+    async fn purge(&self, keys: Vec<Pubkey>);
+}
+
+#[derive(Clone)]
+struct TokenAccountPurge<P: DatabasePool> {
+    pool: P,
+}
+
+impl<P: DatabasePool> TokenAccountPurge<P> {
+    pub fn new(pool: P) -> Self {
+        Self { pool }
+    }
+}
+
+impl<P: DatabasePool> Purge for TokenAccountPurge<P> {
+    async fn purge(&self, keys: Vec<Pubkey>) {
+        let keys = keys
+            .iter()
+            .map(|k| k.to_bytes().to_vec())
+            .collect::<Vec<Vec<u8>>>();
+
+        let conn = self.pool.connection();
+
+        let delete_res = token_accounts::Entity::delete_many()
+            .filter(token_accounts::Column::Pubkey.is_in(keys.iter().map(|a| a.as_slice())))
+            .exec(&conn)
+            .await;
+
+        let keys = keys
+            .iter()
+            .map(|a| bs58::encode(a).into_string())
+            .collect::<Vec<String>>();
+
+        if let Ok(res) = delete_res {
+            debug!(
+                "Successfully purged token_accounts: {:?}",
+                res.rows_affected
+            );
+        } else {
+            error!("Failed to purge token_accounts: {:?}", keys);
+        }
+    }
+}
+
+#[derive(Clone)]
+struct MintPurge<P: DatabasePool> {
+    pool: P,
+}
+
+impl<P: DatabasePool> MintPurge<P> {
+    pub fn new(pool: P) -> Self {
+        Self { pool }
+    }
+}
+
+impl<P: DatabasePool> Purge for MintPurge<P> {
+    async fn purge(&self, keys: Vec<Pubkey>) {
+        let keys = keys
+            .iter()
+            .map(|k| k.to_bytes().to_vec())
+            .collect::<Vec<Vec<u8>>>();
+
+        let conn = self.pool.connection();
+
+        let (delete_res, update_res) = tokio::join!(
+            tokens::Entity::delete_many()
+                .filter(tokens::Column::Mint.is_in(keys.iter().map(|a| a.as_slice())))
+                .exec(&conn),
+            asset::Entity::update_many()
+                .col_expr(asset::Column::Burnt, Expr::value(true))
+                .filter(asset::Column::Burnt.eq(false))
+                .filter(asset::Column::Id.is_in(keys.clone()))
+                .exec(&conn)
+        );
+
+        let keys = keys
+            .iter()
+            .map(|a| bs58::encode(a).into_string())
+            .collect::<Vec<String>>();
+
+        if let Ok(res) = delete_res {
+            debug!("Successfully purged tokens: {:?}", res.rows_affected);
+        } else {
+            error!("Failed to purge tokens: {:?}", keys);
+        }
+
+        if let Ok(res) = update_res {
+            debug!(
+                "Successfully marked assets as burnt: {:?}",
+                res.rows_affected
+            );
+        } else {
+            error!("Failed to update assets: {:?}", keys);
+        }
+    }
+}
+
+#[derive(Debug, Parser, Clone)]
+pub struct Args {
+    /// The number of worker threads
+    #[arg(long, env, default_value = "25")]
+    pub purge_worker_count: u64,
+    /// The number of db entries to process in a single batch
+    #[arg(long, env, default_value = "100")]
+    pub mark_deletion_worker_count: u64,
+    /// The number of db entries to process in a single batch
+    #[arg(long, env, default_value = "100")]
+    pub batch_size: u64,
+}
+
+pub async fn start_ta_purge<P: DatabasePool>(args: Args, db: P, rpc: Rpc) -> Result<()> {
+    let start = tokio::time::Instant::now();
+
+    let (paginate_sender, paginate_receiver) = unbounded_channel::<Vec<Pubkey>>();
+    let (mark_sender, mut mark_receiver) = unbounded_channel::<Vec<Pubkey>>();
+
+    let paginate_db = db.clone();
+
+    let paginate_handle = Paginate::<token_accounts::Entity, P, TokenAccountResult>::build()
+        .pool(paginate_db)
+        .batch_size(args.batch_size)
+        .sender(paginate_sender)
+        .start();
+
+    let mark_handle = MarkDeletion::build()
+        .rpc(rpc)
+        .receiver(paginate_receiver)
+        .sender(mark_sender)
+        .concurrency(args.mark_deletion_worker_count as usize)
+        .start();
+
+    let purge_worker_count = args.purge_worker_count as usize;
+
+    let purge_handle = tokio::spawn(async move {
+        let mut tasks = JoinSet::new();
+        let purge = TokenAccountPurge::new(db);
+
+        while let Some(addresses) = mark_receiver.recv().await {
+            if tasks.len() >= purge_worker_count {
+                tasks.join_next().await;
+            }
+
+            let purge = purge.clone();
+
+            tasks.spawn(async move {
+                purge.purge(addresses).await;
+            });
+        }
+
+        while tasks.join_next().await.is_some() {}
+    });
+
+    let _ = futures::future::join3(paginate_handle, mark_handle, purge_handle).await;
+
+    debug!("Purge took: {:?}", start.elapsed());
+
+    Ok(())
+}
+
+pub async fn start_mint_purge<P: DatabasePool>(args: Args, db: P, rpc: Rpc) -> Result<()> {
+    let start = tokio::time::Instant::now();
+
+    let (paginate_sender, paginate_receiver) = unbounded_channel::<Vec<Pubkey>>();
+    let (mark_sender, mut mark_receiver) = unbounded_channel::<Vec<Pubkey>>();
+
+    let paginate_db = db.clone();
+
+    let paginate_handle = Paginate::<tokens::Entity, P, MintResult>::build()
+        .pool(paginate_db)
+        .batch_size(args.batch_size)
+        .sender(paginate_sender)
+        .start();
+
+    let mark_handle = MarkDeletion::build()
+        .rpc(rpc)
+        .receiver(paginate_receiver)
+        .sender(mark_sender)
+        .concurrency(args.mark_deletion_worker_count as usize)
+        .start();
+
+    let purge_worker_count = args.purge_worker_count as usize;
+
+    let purge_handle = tokio::spawn(async move {
+        let mut tasks = JoinSet::new();
+        let purge = MintPurge::new(db);
+
+        while let Some(addresses) = mark_receiver.recv().await {
+            if tasks.len() >= purge_worker_count {
+                tasks.join_next().await;
+            }
+
+            let purge = purge.clone();
+
+            tasks.spawn(async move {
+                purge.purge(addresses).await;
+            });
+        }
+
+        while tasks.join_next().await.is_some() {}
+    });
+
+    let _ = futures::future::join3(paginate_handle, mark_handle, purge_handle).await;
+
+    debug!("Purge took: {:?}", start.elapsed());
+
+    Ok(())
+}

--- a/ops/src/purge/purger.rs
+++ b/ops/src/purge/purger.rs
@@ -2,17 +2,20 @@ use anyhow::Result;
 use borsh::BorshDeserialize;
 use clap::Parser;
 use das_core::{DatabasePool, Rpc};
-use digital_asset_types::dao::{asset, token_accounts, tokens};
+use digital_asset_types::dao::{
+    asset, asset_authority, asset_creators, asset_data, asset_grouping, cl_audits_v2, cl_items,
+    token_accounts, tokens,
+};
 use log::{debug, error};
 use sea_orm::{
     sea_query::Expr, ColumnTrait, EntityTrait, FromQueryResult, PaginatorTrait, QueryFilter,
     QuerySelect,
 };
+use sea_orm::{DatabaseConnection, Order, QueryOrder, TransactionTrait};
 use solana_sdk::{bs58, pubkey};
+use solana_sdk::{pubkey::Pubkey, signature::Signature};
 use std::marker::{Send, Sync};
-
-use solana_sdk::pubkey::Pubkey;
-use tokio::sync::mpsc::unbounded_channel;
+use tokio::sync::mpsc::{unbounded_channel, Receiver, Sender};
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
 use tokio::task::{JoinHandle, JoinSet};
 
@@ -328,12 +331,15 @@ pub struct Args {
     /// The number of worker threads
     #[arg(long, env, default_value = "25")]
     pub purge_worker_count: u64,
-    /// The number of db entries to process in a single batch
+    /// The number of concurrent workers checking account deletion status
     #[arg(long, env, default_value = "100")]
     pub mark_deletion_worker_count: u64,
     /// The number of db entries to process in a single batch
     #[arg(long, env, default_value = "100")]
     pub batch_size: u64,
+    /// Channel size for db pagination, to add backpressure and avoid memory consumption
+    #[arg(long, env, default_value = "10")]
+    pub paginate_channel_size: u64,
 }
 
 pub async fn start_ta_purge<P: DatabasePool>(args: Args, db: P, rpc: Rpc) -> Result<()> {
@@ -432,4 +438,394 @@ pub async fn start_mint_purge<P: DatabasePool>(args: Args, db: P, rpc: Rpc) -> R
     debug!("Purge took: {:?}", start.elapsed());
 
     Ok(())
+}
+
+#[derive(FromQueryResult, Debug)]
+struct CnftQueryResult {
+    id: i64,
+    tx: Vec<u8>,
+    leaf_idx: i64,
+    tree: Vec<u8>,
+    seq: i64,
+}
+
+struct PaginateCnft<P: DatabasePool> {
+    pool: Option<P>,
+    batch_size: Option<u64>,
+    sender: Option<Sender<Vec<CnftQueryResult>>>,
+    only_trees: Option<Vec<Vec<u8>>>,
+}
+
+impl<P: DatabasePool> PaginateCnft<P> {
+    pub const DEFAULT_DB_BATCH_SIZE: u64 = 100;
+
+    fn build() -> Self {
+        Self {
+            pool: None,
+            batch_size: None,
+            sender: None,
+            only_trees: None,
+        }
+    }
+
+    fn pool(mut self, pool: P) -> Self {
+        self.pool = Some(pool);
+        self
+    }
+
+    fn batch_size(mut self, batch_size: u64) -> Self {
+        self.batch_size = Some(batch_size);
+        self
+    }
+
+    fn sender(mut self, sender: Sender<Vec<CnftQueryResult>>) -> Self {
+        self.sender = Some(sender);
+        self
+    }
+
+    fn only_trees(mut self, only_trees: Option<Vec<Vec<u8>>>) -> Self {
+        self.only_trees = only_trees;
+        self
+    }
+
+    fn start(self) -> JoinHandle<Result<()>> {
+        tokio::spawn(async move {
+            let pool = self.pool.expect("Pool not set");
+            let sender = self.sender.expect("Sender not set");
+            let batch_size = self.batch_size.unwrap_or(Self::DEFAULT_DB_BATCH_SIZE);
+            let conn = pool.connection();
+            let mut last_id = 0;
+
+            loop {
+                let mut txs_batch = cl_audits_v2::Entity::find();
+
+                if let Some(only_trees) = self.only_trees.clone() {
+                    txs_batch = txs_batch.filter(cl_audits_v2::Column::Tree.is_in(only_trees));
+                }
+
+                let txs_batch = txs_batch
+                    .filter(cl_audits_v2::Column::Id.gt(last_id))
+                    .select_only()
+                    .columns([
+                        cl_audits_v2::Column::Id,
+                        cl_audits_v2::Column::Tx,
+                        cl_audits_v2::Column::LeafIdx,
+                        cl_audits_v2::Column::Tree,
+                        cl_audits_v2::Column::Seq,
+                    ])
+                    .order_by(cl_audits_v2::Column::Id, Order::Asc)
+                    .limit(batch_size)
+                    .into_model::<CnftQueryResult>()
+                    .all(&conn)
+                    .await?;
+
+                match txs_batch.last() {
+                    Some(last) => last_id = last.id,
+                    None => break,
+                }
+
+                if sender.send(txs_batch).await.is_err() {
+                    error!("Failed to send keys");
+                }
+            }
+
+            Ok(())
+        })
+    }
+}
+
+struct MarkDeletionCnft {
+    rpc: Option<Rpc>,
+    receiver: Option<Receiver<Vec<CnftQueryResult>>>,
+    sender: Option<UnboundedSender<CnftQueryResult>>,
+    concurrency: Option<usize>,
+}
+
+impl MarkDeletionCnft {
+    pub const DEFAULT_CONCURRENCY: usize = 10;
+
+    fn build() -> Self {
+        Self {
+            rpc: None,
+            receiver: None,
+            sender: None,
+            concurrency: None,
+        }
+    }
+
+    fn rpc(mut self, rpc: Rpc) -> Self {
+        self.rpc = Some(rpc);
+        self
+    }
+
+    fn receiver(mut self, receiver: Receiver<Vec<CnftQueryResult>>) -> Self {
+        self.receiver = Some(receiver);
+        self
+    }
+
+    fn sender(mut self, sender: UnboundedSender<CnftQueryResult>) -> Self {
+        self.sender = Some(sender);
+        self
+    }
+
+    fn concurrency(mut self, concurrency: usize) -> Self {
+        self.concurrency = Some(concurrency);
+        self
+    }
+
+    fn start(self) -> JoinHandle<()> {
+        let rpc = self.rpc.expect("Rpc not set");
+        let mut receiver = self.receiver.expect("Receiver not set");
+        let sender = self.sender.expect("Sender not set");
+        let concurrency = self.concurrency.unwrap_or(Self::DEFAULT_CONCURRENCY);
+
+        tokio::spawn(async move {
+            let mut tasks = JoinSet::new();
+
+            while let Some(chunk) = receiver.recv().await {
+                for tx_query_result in chunk {
+                    if tasks.len() >= concurrency {
+                        tasks.join_next().await;
+                    }
+
+                    let rpc = rpc.clone();
+                    let sender = sender.clone();
+
+                    tasks.spawn(async move {
+                        let sig = match Signature::try_from(tx_query_result.tx.as_ref()) {
+                            Ok(sig) => sig,
+                            Err(e) => {
+                                error!("Failed to parse signature: {:?}", e);
+                                return;
+                            }
+                        };
+
+                        match rpc.get_transaction(&sig).await {
+                            Ok(tx) => match &tx.transaction.meta {
+                                Some(meta) => {
+                                    if meta.err.is_some() {
+                                        if let Err(e) = sender.send(tx_query_result) {
+                                            error!("Failed to send marked leaves {:?}", e);
+                                        }
+                                    }
+                                }
+                                None => error!("Non existent tx meta on tx: {:?}", sig),
+                            },
+                            Err(e) => {
+                                tracing::error!("Failed to get transaction {:?}", e);
+                            }
+                        }
+                    });
+                }
+            }
+
+            while tasks.join_next().await.is_some() {}
+        })
+    }
+}
+
+trait PurgeCnft {
+    async fn purge(&self, leaf_idx: i64, tree: Vec<u8>, tx_seq: i64) -> Result<()>;
+}
+
+#[derive(Clone)]
+struct ErrCnftPurge<P: DatabasePool> {
+    pool: P,
+}
+
+impl<P: DatabasePool> ErrCnftPurge<P> {
+    pub fn new(pool: P) -> Self {
+        Self { pool }
+    }
+}
+
+impl<P: DatabasePool> PurgeCnft for ErrCnftPurge<P> {
+    async fn purge(&self, leaf_idx: i64, tree: Vec<u8>, tx_seq: i64) -> Result<()> {
+        let conn = self.pool.connection();
+
+        let (asset, _) = Pubkey::find_program_address(
+            &[b"asset", &tree, &leaf_idx.to_le_bytes()],
+            &mpl_bubblegum::ID,
+        );
+        let asset_bytes = asset.to_bytes().to_vec();
+
+        let node_path = calculate_node_path(leaf_idx, tree.clone(), &conn).await?;
+
+        let multi_txn = conn.begin().await?;
+
+        let asset_data = asset_data::Entity::delete_by_id(asset_bytes.clone())
+            .exec(&multi_txn)
+            .await?;
+
+        debug!("asset_data DeleteResult: {:?}", asset_data);
+
+        let asset = asset::Entity::delete_by_id(asset_bytes.clone())
+            .exec(&multi_txn)
+            .await?;
+
+        debug!("asset DeleteResult: {:?}", asset);
+
+        let asset_creators = asset_creators::Entity::delete_many()
+            .filter(asset_creators::Column::AssetId.eq(asset_bytes.clone()))
+            .exec(&multi_txn)
+            .await?;
+
+        debug!("asset_creators DeleteResult: {:?}", asset_creators);
+
+        let asset_authority = asset_authority::Entity::delete_many()
+            .filter(asset_authority::Column::AssetId.eq(asset_bytes.clone()))
+            .exec(&multi_txn)
+            .await?;
+
+        debug!("asset_authority DeleteResult: {:?}", asset_authority);
+
+        let asset_grouping = asset_grouping::Entity::delete_many()
+            .filter(asset_grouping::Column::AssetId.eq(asset_bytes))
+            .exec(&multi_txn)
+            .await?;
+
+        debug!("asset_grouping DeleteResult: {:?}", asset_grouping);
+
+        let cl_items = cl_items::Entity::delete_many()
+            .filter(cl_items::Column::Tree.eq(tree.clone()))
+            .filter(cl_items::Column::NodeIdx.is_in(node_path))
+            .filter(cl_items::Column::Seq.lte(tx_seq))
+            .exec(&multi_txn)
+            .await?;
+
+        debug!("cl_items DeleteResult: {:?}", cl_items);
+
+        // Remove all txs for the asset from cl_audits_v2 so that the asset can be re-indexed by the backfiller
+        let cl_audits_v2 = cl_audits_v2::Entity::delete_many()
+            .filter(cl_audits_v2::Column::LeafIdx.eq(leaf_idx))
+            .filter(cl_audits_v2::Column::Tree.eq(tree.clone()))
+            .exec(&multi_txn)
+            .await?;
+        debug!("cl_audits_v2 DeleteResult: {:?}", cl_audits_v2);
+
+        multi_txn.commit().await?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Parser, Clone)]
+pub struct CnftArgs {
+    /// The list of trees to verify. If not specified, all trees will be crawled.
+    #[arg(long, env, use_value_delimiter = true)]
+    pub only_trees: Option<Vec<String>>,
+    #[clap(flatten)]
+    pub purge_args: Args,
+}
+
+pub async fn start_cnft_purge<P: DatabasePool>(args: CnftArgs, db: P, rpc: Rpc) -> Result<()> {
+    let start = tokio::time::Instant::now();
+
+    let purge_worker_count = args.purge_args.purge_worker_count as usize;
+    let only_trees = args.only_trees.map(|trees| {
+        trees
+            .into_iter()
+            .filter_map(|tree| {
+                bs58::decode(tree.clone()).into_vec().ok().or_else(|| {
+                    error!("Failed to decode tree: {:?}", tree);
+                    None
+                })
+            })
+            .collect()
+    });
+
+    let (paginate_sender, paginate_receiver) = tokio::sync::mpsc::channel::<Vec<CnftQueryResult>>(
+        args.purge_args.paginate_channel_size as usize,
+    );
+    let (mark_sender, mut mark_receiver) = unbounded_channel::<CnftQueryResult>();
+
+    let paginate_handle = PaginateCnft::<P>::build()
+        .pool(db.clone())
+        .batch_size(args.purge_args.batch_size)
+        .sender(paginate_sender)
+        .only_trees(only_trees)
+        .start();
+
+    let mark_handle = MarkDeletionCnft::build()
+        .rpc(rpc.clone())
+        .receiver(paginate_receiver)
+        .sender(mark_sender)
+        .concurrency(args.purge_args.mark_deletion_worker_count as usize)
+        .start();
+
+    let db = db.clone();
+
+    let purge_handle = tokio::spawn(async move {
+        let mut tasks = JoinSet::new();
+        let purge = ErrCnftPurge::new(db);
+
+        while let Some(tx_query_result) = mark_receiver.recv().await {
+            if tasks.len() >= purge_worker_count {
+                tasks.join_next().await;
+            }
+
+            let purge = purge.clone();
+
+            tasks.spawn(async move {
+                if let Err(e) = purge
+                    .purge(
+                        tx_query_result.leaf_idx,
+                        tx_query_result.tree,
+                        tx_query_result.seq,
+                    )
+                    .await
+                {
+                    error!("Failed to purge asset {:?}", e);
+                }
+            });
+        }
+
+        while tasks.join_next().await.is_some() {}
+    });
+
+    let _ = futures::future::join3(paginate_handle, mark_handle, purge_handle).await;
+
+    debug!("Purge took: {:?}", start.elapsed());
+
+    Ok(())
+}
+
+/// Calculate all cl_items nodes in the path for the given leaf
+async fn calculate_node_path(
+    leaf_idx: i64,
+    tree: Vec<u8>,
+    db: &DatabaseConnection,
+) -> Result<Vec<i64>> {
+    let mut node_path = vec![];
+
+    let mut leaf_node_idx = get_leaf_node_idx(leaf_idx, tree, db).await?;
+
+    if leaf_node_idx < 1 {
+        error!("Leaf node idx is less than 1: {:?}", leaf_node_idx);
+        return Err(anyhow::anyhow!("Leaf node idx is less than 1"));
+    }
+
+    while leaf_node_idx != 1 {
+        node_path.push(leaf_node_idx);
+        leaf_node_idx /= 2;
+    }
+
+    node_path.push(1);
+
+    debug!("node_path: {:?}", node_path);
+
+    Ok(node_path)
+}
+
+async fn get_leaf_node_idx(leaf_idx: i64, tree: Vec<u8>, db: &DatabaseConnection) -> Result<i64> {
+    let cl_item = cl_items::Entity::find()
+        .filter(cl_items::Column::Tree.eq(tree))
+        .filter(cl_items::Column::LeafIdx.eq(leaf_idx))
+        .one(db)
+        .await?;
+
+    match cl_item {
+        Some(cl_item) => Ok(cl_item.node_idx),
+        None => Err(anyhow::anyhow!("No cl_item found")),
+    }
 }


### PR DESCRIPTION
- [x]  Add purge token_accounts cmd to ops to delete token_accounts which are closed on-chain
- [x]  Add purge mint cmd to ops to mark assets as burnt
- [x]  Add a wrapper for DB and Rpc mock to use in tests