### PR TITLE
`fix` : searchAsset query with tokenType, ownerType filters

### DIFF
--- a/integration_tests/tests/integration_tests/show_collection_metadata_option_tests.rs
+++ b/integration_tests/tests/integration_tests/show_collection_metadata_option_tests.rs
@@ -25,8 +25,8 @@ async fn test_get_asset_with_show_collection_metadata_option() {
 
     let seeds: Vec<SeedEvent> = seed_accounts([
         "AH6wj7T8Ke5nbukjtcobjjs1CDWUcQxndtnLkKAdrSrM",
-        "7fXKY9tPpvYsdbSNyesUqo27WYC6ZsBEULdtngGHqLCK",
         "3crBqZZsHhoLphM55MG4KRW6SbNzFEBFnehw7PW7ZRKt",
+        "7fXKY9tPpvYsdbSNyesUqo27WYC6ZsBEULdtngGHqLCK",
     ]);
 
     apply_migrations_and_delete_data(setup.db.clone()).await;

--- a/integration_tests/tests/integration_tests/snapshots/integration_tests__fungibles_and_token_extensions_tests__fungible_token_get_asset_scenario_1.snap
+++ b/integration_tests/tests/integration_tests/snapshots/integration_tests__fungibles_and_token_extensions_tests__fungible_token_get_asset_scenario_1.snap
@@ -1,6 +1,7 @@
 ---
 source: integration_tests/tests/integration_tests/fungibles_and_token_extensions_tests.rs
 expression: response
+snapshot_kind: text
 ---
 {
   "interface": "Custom",

--- a/integration_tests/tests/integration_tests/snapshots/integration_tests__fungibles_and_token_extensions_tests__token_extensions_get_asset_scenario_1.snap
+++ b/integration_tests/tests/integration_tests/snapshots/integration_tests__fungibles_and_token_extensions_tests__token_extensions_get_asset_scenario_1.snap
@@ -1,6 +1,7 @@
 ---
 source: integration_tests/tests/integration_tests/fungibles_and_token_extensions_tests.rs
 expression: response
+snapshot_kind: text
 ---
 {
   "interface": "Custom",

--- a/integration_tests/tests/integration_tests/snapshots/integration_tests__regular_nft_tests__reg_get_asset_batch-only-2.snap
+++ b/integration_tests/tests/integration_tests/snapshots/integration_tests__regular_nft_tests__reg_get_asset_batch-only-2.snap
@@ -1,6 +1,7 @@
 ---
 source: integration_tests/tests/integration_tests/regular_nft_tests.rs
 expression: response
+snapshot_kind: text
 ---
 [
   {

--- a/integration_tests/tests/integration_tests/snapshots/integration_tests__show_collection_metadata_option_tests__get_asset_with_show_collection_metadata_option.snap
+++ b/integration_tests/tests/integration_tests/snapshots/integration_tests__show_collection_metadata_option_tests__get_asset_with_show_collection_metadata_option.snap
@@ -1,6 +1,7 @@
 ---
 source: integration_tests/tests/integration_tests/show_collection_metadata_option_tests.rs
 expression: response
+snapshot_kind: text
 ---
 {
   "interface": "ProgrammableNFT",


### PR DESCRIPTION
Avoid seq scan for TokenType::Fungible case , update ownerType  filters and conditions

`Note` : when using TokenType::All along with ownerAddress, due to nature of the query db performs a seq scan though we have setup indexes for that  , This can be fixed by using `Unions` ( query on asset table union  query on asset table and left join with token_accounts table). In order to use unions we need to restructure the code and handle this case explicitly
