### PR TITLE
`impr` : add composite index (owner,amount) and (mint,amount) on token_accounts table

### DIFF
--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -46,7 +46,8 @@ mod m20240520_120101_add_mpl_core_external_plugins_columns;
 mod m20240718_161232_change_supply_columns_to_numeric;
 mod m20241119_060310_add_token_inscription_enum_variant;
 mod m20250213_053451_add_idx_token_accounts_owner;
-
+mod m20250313_095336_drop_idx_token_accounts_owner_and_idx_ta_mint;
+mod m20250313_095449_add_idx_ta_owner_amount_and_idx_ta_mint_amount;
 pub mod model;
 
 pub struct Migrator;
@@ -101,6 +102,8 @@ impl MigratorTrait for Migrator {
             Box::new(m20240718_161232_change_supply_columns_to_numeric::Migration),
             Box::new(m20241119_060310_add_token_inscription_enum_variant::Migration),
             Box::new(m20250213_053451_add_idx_token_accounts_owner::Migration),
+            Box::new(m20250313_095336_drop_idx_token_accounts_owner_and_idx_ta_mint::Migration),
+            Box::new(m20250313_095449_add_idx_ta_owner_amount_and_idx_ta_mint_amount::Migration),
         ]
     }
 }

--- a/migration/src/m20250313_095336_drop_idx_token_accounts_owner_and_idx_ta_mint.rs
+++ b/migration/src/m20250313_095336_drop_idx_token_accounts_owner_and_idx_ta_mint.rs
@@ -1,0 +1,50 @@
+use super::model::table::TokenAccounts;
+use sea_orm::{ConnectionTrait, DatabaseBackend, Statement};
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("token_accounts_owner_idx")
+                    .table(TokenAccounts::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("ta_mint")
+                    .table(TokenAccounts::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+
+        conn.execute(Statement::from_string(
+            DatabaseBackend::Postgres,
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS token_accounts_owner_idx ON token_accounts (owner);"
+                .to_string(),
+        ))
+        .await?;
+
+        conn.execute(Statement::from_string(
+            DatabaseBackend::Postgres,
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ta_mint ON token_accounts (mint);".to_string(),
+        ))
+        .await?;
+
+        Ok(())
+    }
+}

--- a/migration/src/m20250313_095449_add_idx_ta_owner_amount_and_idx_ta_mint_amount.rs
+++ b/migration/src/m20250313_095449_add_idx_ta_owner_amount_and_idx_ta_mint_amount.rs
@@ -1,0 +1,51 @@
+use super::model::table::TokenAccounts;
+use sea_orm::{ConnectionTrait, DatabaseBackend, Statement};
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let conn = manager.get_connection();
+
+        conn.execute(Statement::from_string(
+            DatabaseBackend::Postgres,
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ta_owner_amount ON token_accounts (owner,amount);"
+                .to_string(),
+        ))
+        .await?;
+
+        conn.execute(Statement::from_string(
+            DatabaseBackend::Postgres,
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS ta_mint_amount ON token_accounts (mint,amount);"
+                .to_string(),
+        ))
+        .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("ta_owner_amount")
+                    .table(TokenAccounts::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .drop_index(
+                Index::drop()
+                    .name("ta_mint_amount")
+                    .table(TokenAccounts::Table)
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
getTokenAccounts calls were kind of slow as we have amount > 0 condition , adding a composite index (owner,amount) can fix this potentially and reduce the latency

@kespinola let me know if we want to add amount_greater_than or amount_less_than filters here