### PR TITLE
Drop amount zero tokens from search all

### DIFF
--- a/digital_asset_types/src/dao/mod.rs
+++ b/digital_asset_types/src/dao/mod.rs
@@ -176,6 +176,7 @@ impl SearchAssetsQuery {
                                     .select_only()
                                     .column(token_accounts::Column::Mint)
                                     .filter(token_accounts::Column::Owner.eq(o.clone()))
+                                    .filter(token_accounts::Column::Amount.gt(0))
                                     .into_query(),
                             ))
                     }


### PR DESCRIPTION
## Changes
- On Eclipse we have token accounts that aren't close but assigned to the user. This lead to search finding mints that they don't actually own but have the account. Only return the asset if the amount held i the TA is greater than 0.