### PR TITLE
fix : retreive fungible assets for get_assets_owner call when show_fungible option is active

### DIFF
--- a/das_api/src/api/api_impl.rs
+++ b/das_api/src/api/api_impl.rs
@@ -263,6 +263,7 @@ impl ApiContract for DasApi {
         let options = options.unwrap_or_default();
         let page_options =
             self.validate_pagination(limit, page, &before, &after, &cursor, Some(sort_by))?;
+        println!("get assets by owner");
         get_assets_by_owner(
             &self.db_connection,
             owner_address_bytes,

--- a/digital_asset_types/src/dapi/assets_by_owner.rs
+++ b/digital_asset_types/src/dapi/assets_by_owner.rs
@@ -27,6 +27,7 @@ pub async fn get_assets_by_owner(
         options,
     )
     .await?;
+    println!("assets: {:?}", assets);
     Ok(build_asset_response(
         assets,
         page_options.limit,


### PR DESCRIPTION
Problem : for fungible assets we dont store owner on the asset_table as it is owned by a lot of ppl and currently we are doing a owner match on asset table so we are not able to get fungible assets due to this

Solution : if show_fungible is activated for get_assets_by_owner 
1. perform a join on asset and token_accounts table filtering by owner and matching token mint with asset_id
2. return all the assets retrieved from this join 