### PR TITLE
Add getSlot and getHealth RPC methods

### DIFF
--- a/das_api/src/api/api_impl.rs
+++ b/das_api/src/api/api_impl.rs
@@ -159,14 +159,14 @@ pub fn not_found(asset_id: &String) -> DbErr {
 #[document_rpc]
 #[async_trait]
 impl ApiContract for DasApi {
-    async fn check_health(self: &DasApi) -> Result<(), DasApiError> {
+    async fn check_health(self: &DasApi) -> Result<String, DasApiError> {
         self.get_connection()
             .execute(Statement::from_string(
                 DbBackend::Postgres,
                 "SELECT 1".to_string(),
             ))
             .await?;
-        Ok(())
+        Ok("ok".to_string())
     }
 
     async fn get_slot(self: &DasApi, _payload: Option<GetSlot>) -> Result<u64, DasApiError> {

--- a/das_api/src/api/api_impl.rs
+++ b/das_api/src/api/api_impl.rs
@@ -1,5 +1,6 @@
 use crate::error::DasApiError;
 use crate::validation::{validate_opt_pubkey, validate_search_with_name};
+use digital_asset_types::dao::scopes::slot::get_latest_slot;
 use digital_asset_types::{
     dao::{
         scopes::{
@@ -166,6 +167,12 @@ impl ApiContract for DasApi {
             ))
             .await?;
         Ok(())
+    }
+
+    async fn get_slot(self: &DasApi, _payload: Option<GetSlot>) -> Result<u64, DasApiError> {
+        let slot = get_latest_slot(&self.get_connection()).await?;
+
+        Ok(slot)
     }
 
     async fn get_asset_proof(

--- a/das_api/src/api/mod.rs
+++ b/das_api/src/api/mod.rs
@@ -203,6 +203,9 @@ pub struct GetTokenAccounts {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct GetSlot(#[serde(default)] pub Option<CommitmentConfig>);
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct GetTokenLargestAccounts(pub String, #[serde(default)] pub Option<CommitmentConfig>);
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
@@ -279,6 +282,8 @@ pub struct GetTokenAccountsByOwner(
 #[async_trait]
 pub trait ApiContract: Send + Sync + 'static {
     async fn check_health(&self) -> Result<(), DasApiError>;
+    #[rpc(name = "getSlot", summary = "Get highest slot")]
+    async fn get_slot(&self, payload: Option<GetSlot>) -> Result<u64, DasApiError>;
     #[rpc(
         name = "getAssetProof",
         params = "named",

--- a/das_api/src/api/mod.rs
+++ b/das_api/src/api/mod.rs
@@ -281,7 +281,7 @@ pub struct GetTokenAccountsByOwner(
 #[document_rpc]
 #[async_trait]
 pub trait ApiContract: Send + Sync + 'static {
-    async fn check_health(&self) -> Result<(), DasApiError>;
+    async fn check_health(&self) -> Result<String, DasApiError>;
     #[rpc(name = "getSlot", summary = "Get highest slot")]
     async fn get_slot(&self, payload: Option<GetSlot>) -> Result<u64, DasApiError>;
     #[rpc(

--- a/das_api/src/builder.rs
+++ b/das_api/src/builder.rs
@@ -14,6 +14,12 @@ impl RpcApiBuilder {
             debug!("Checking Health");
             rpc_context.check_health().await.map_err(Into::into)
         })?;
+        module.register_alias("getHealth", "healthz")?;
+        module.register_async_method("get_slot", |rpc_params, rpc_context| async move {
+            let payload = rpc_params.parse::<Option<GetSlot>>()?;
+            rpc_context.get_slot(payload).await.map_err(Into::into)
+        })?;
+        module.register_alias("getSlot", "get_slot")?;
 
         module.register_async_method("get_asset_proof", |rpc_params, rpc_context| async move {
             let payload = rpc_params.parse::<GetAssetProof>()?;

--- a/integration_tests/tests/integration_tests/main.rs
+++ b/integration_tests/tests/integration_tests/main.rs
@@ -10,4 +10,5 @@ mod mpl_core_tests;
 mod ops_purge_tests;
 mod regular_nft_tests;
 mod search_assets_tests;
+mod slot_tests;
 mod token_accounts_tests;

--- a/integration_tests/tests/integration_tests/slot_tests.rs
+++ b/integration_tests/tests/integration_tests/slot_tests.rs
@@ -1,0 +1,25 @@
+use super::common::*;
+use das_api::api::ApiContract;
+use digital_asset_types::dao::slot_metas;
+use function_name::named;
+use sea_orm::{ActiveValue::Set, EntityTrait};
+use serial_test::serial;
+
+#[tokio::test]
+#[serial]
+#[named]
+async fn test_get_slot() {
+    let name = trim_test_name(function_name!());
+    let setup = TestSetup::new(name.clone()).await;
+
+    apply_migrations_and_delete_data(setup.db.clone()).await;
+    let model = slot_metas::ActiveModel { slot: Set(12345) };
+    slot_metas::Entity::insert(model)
+        .exec(&setup.das_api.get_connection())
+        .await
+        .unwrap();
+
+    let response = setup.das_api.get_slot(None).await.unwrap();
+
+    insta::assert_json_snapshot!(name, response);
+}

--- a/integration_tests/tests/integration_tests/snapshots/integration_tests__slot_tests__get_slot.snap
+++ b/integration_tests/tests/integration_tests/snapshots/integration_tests__slot_tests__get_slot.snap
@@ -1,0 +1,5 @@
+---
+source: integration_tests/tests/integration_tests/slot_tests.rs
+expression: response
+---
+12345


### PR DESCRIPTION
## Changes
- Implement Solana RPC spec for `getSlot`
- Expose `getHealth` method for basic postgres connection test

https://solana.com/docs/rpc/http/getslot

```
# request
{
	"jsonrpc": "2.0",
	"id": "1",
	"method": "getHealth"
}

# response
{
	"jsonrpc": "2.0",
	"result": "ok",
	"id": "1"
}
```

```
# request
{
	"jsonrpc": "2.0",
	"id": "1",
	"method": "getSlot"
}

# response
{
	"jsonrpc": "2.0",
	"result": 12345,
	"id": "1"
}
```