### PR TITLE
Write Account Snapshots in Batches with More Concurrency

### DIFF
--- a/grpc-ingest/config-snapshot.example.yml
+++ b/grpc-ingest/config-snapshot.example.yml
@@ -29,7 +29,16 @@ postgres:
   # max connections
   max_connections: 50
 
-subscription:
+program_transform:
+  max_workers: 20
+  buffer_capacity: 1_000
+
+snapshot_write:
+  max_workers: 20
+  buffer_capacity: 1_000
+  batch_size: 1_000
+
+snapshot_read:
   stream:
     name: SNAPSHOTS
     max_len: 100_000_000
@@ -40,20 +49,13 @@ subscription:
         - TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA
         - TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb
 
-download_metadata_publish:
-  # maximum number of concurrent tasks for processing.
-  max_concurrency: 10
-  # stream name
-  stream_name: METADATA_JSONS
-  # stream max length
-  stream_maxlen: 100_000_000
-  # number of pipelines that can be processed concurrently
-  pipeline_count: 10
-  # pipeline max idle time in milliseconds
-  pipeline_max_idle_ms: 150
+# download metadata configuration for the ingester
+download_metadata:
+  metadata_json_download_worker_count: 3
+  metadata_json_download_worker_request_timeout: 150
 
 # snapshots configuration for the ingester
-snapshots:
+snapshot_process:
   # stream name
   name: SNAPSHOTS
   # maximum number of concurrent tasks for processing.

--- a/grpc-ingest/src/config.rs
+++ b/grpc-ingest/src/config.rs
@@ -243,12 +243,71 @@ impl ConfigIngest {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+pub struct ConfigAccountSnapshotWriter {
+    #[serde(
+        default = "ConfigAccountSnapshotWriter::default_batch_size",
+        deserialize_with = "deserialize_usize_str"
+    )]
+    pub batch_size: usize,
+    #[serde(
+        default = "ConfigAccountSnapshotWriter::default_channel_capacity",
+        deserialize_with = "deserialize_usize_str"
+    )]
+    pub channel_capacity: usize,
+    #[serde(
+        default = "ConfigAccountSnapshotWriter::default_max_workers",
+        deserialize_with = "deserialize_usize_str"
+    )]
+    pub max_workers: usize,
+}
+
+impl ConfigAccountSnapshotWriter {
+    pub const fn default_batch_size() -> usize {
+        1_000
+    }
+
+    pub const fn default_channel_capacity() -> usize {
+        100_000
+    }
+
+    pub const fn default_max_workers() -> usize {
+        20
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct ConfigProgramTransformerRunner {
+    #[serde(
+        default = "ConfigProgramTransformerRunner::default_max_workers",
+        deserialize_with = "deserialize_usize_str"
+    )]
+    pub max_workers: usize,
+    #[serde(
+        default = "ConfigProgramTransformerRunner::default_buffer_capacity",
+        deserialize_with = "deserialize_usize_str"
+    )]
+    pub buffer_capacity: usize,
+}
+
+impl ConfigProgramTransformerRunner {
+    pub const fn default_max_workers() -> usize {
+        20
+    }
+
+    pub const fn default_buffer_capacity() -> usize {
+        1_000
+    }
+}
+
+#[derive(Debug, Clone, Deserialize)]
 pub struct ConfigSnapshot {
     pub redis: ConfigGrpcRedis,
     pub postgres: ConfigPostgres,
     pub grpc: ConfigGeyser,
-    pub subscription: ConfigSubscription,
-    pub snapshots: ConfigIngestStream,
+    pub program_transform: ConfigProgramTransformerRunner,
+    pub snapshot_write: ConfigAccountSnapshotWriter,
+    pub snapshot_process: ConfigIngestStream,
+    pub snapshot_read: ConfigSubscription,
     pub download_metadata: MetadataJsonDownloadWorkerArgs,
 }
 
@@ -256,12 +315,9 @@ impl From<ConfigSnapshot> for ConfigGrpc {
     fn from(snapshot: ConfigSnapshot) -> Self {
         let subscriptions = {
             let mut map = HashMap::new();
-
-            map.insert("snapshot".to_string(), snapshot.subscription);
-
+            map.insert("snapshot".to_string(), snapshot.snapshot_read);
             map
         };
-
         ConfigGrpc {
             geyser: snapshot.grpc,
             subscriptions,

--- a/grpc-ingest/src/prom.rs
+++ b/grpc-ingest/src/prom.rs
@@ -7,11 +7,12 @@ use {
         service::{make_service_fn, service_fn},
         Body, Request, Response, Server, StatusCode,
     },
-    program_transformers::error::ProgramTransformerError,
+    program_transformers::{error::ProgramTransformerError, AccountInfo},
     prometheus::{
         HistogramOpts, HistogramVec, IntCounterVec, IntGaugeVec, Opts, Registry, TextEncoder,
     },
     std::{net::SocketAddr, sync::Once},
+    tokio::sync::mpsc::error::SendError,
     tracing::{error, info},
 };
 
@@ -302,6 +303,7 @@ pub enum ProgramTransformerTaskStatusKind {
     DownloadMetadataFetchError,
     DownloadMetadataAssetNotFound,
     RedisMessageDeserializeError,
+    SnapshotSendError,
 }
 
 impl From<ProgramTransformerError> for ProgramTransformerTaskStatusKind {
@@ -366,6 +368,12 @@ impl From<sea_orm::DbErr> for ProgramTransformerTaskStatusKind {
     }
 }
 
+impl From<SendError<AccountInfo>> for ProgramTransformerTaskStatusKind {
+    fn from(_: SendError<AccountInfo>) -> Self {
+        ProgramTransformerTaskStatusKind::SnapshotSendError
+    }
+}
+
 impl ProgramTransformerTaskStatusKind {
     pub const fn to_str(self) -> &'static str {
         match self {
@@ -393,6 +401,7 @@ impl ProgramTransformerTaskStatusKind {
             ProgramTransformerTaskStatusKind::RedisMessageDeserializeError => {
                 "redis_message_deserialize_error"
             }
+            ProgramTransformerTaskStatusKind::SnapshotSendError => "snapshot_send_error",
         }
     }
 }

--- a/grpc-ingest/src/redis.rs
+++ b/grpc-ingest/src/redis.rs
@@ -22,6 +22,7 @@ use {
     solana_sdk::{pubkey::Pubkey, signature::Signature},
     std::{collections::HashMap, marker::PhantomData, sync::Arc},
     tokio::{
+        sync::mpsc::{error::SendError, Sender},
         task::JoinSet,
         time::{sleep, Duration},
     },
@@ -179,6 +180,8 @@ pub enum IngestMessageError {
     ProgramTransformer(#[from] program_transformers::error::ProgramTransformerError),
     #[error("Download metadata JSON task error: {0}")]
     DownloadMetadataJson(#[from] das_core::MetadataJsonTaskError),
+    #[error("Snapshot send error: {0}")]
+    SnapshotSend(#[from] SendError<AccountInfo>),
 }
 
 pub struct IngestStreamStop {
@@ -282,11 +285,11 @@ impl Clone for AccountHandle {
         Self(Arc::clone(&self.0))
     }
 }
-pub struct SnapshotHandle(Arc<ProgramTransformer>);
+pub struct SnapshotHandle(Sender<AccountInfo>);
 
 impl SnapshotHandle {
-    pub const fn new(program_transformer: Arc<ProgramTransformer>) -> Self {
-        Self(program_transformer)
+    pub const fn new(sender: Sender<AccountInfo>) -> Self {
+        Self(sender)
     }
 }
 
@@ -295,22 +298,21 @@ impl MessageHandler for SnapshotHandle {
         &self,
         input: HashMap<String, RedisValue>,
     ) -> BoxFuture<'static, Result<(), IngestMessageError>> {
-        let program_transformer = Arc::clone(&self.0);
+        let sender = self.0.clone();
 
         Box::pin(async move {
-            let account = AccountInfo::try_parse_msg(input)?;
+            let account_info = AccountInfo::try_parse_msg(input)?;
 
-            program_transformer
-                .handle_account_snapshot_update(&account)
-                .await
-                .map_err(IngestMessageError::ProgramTransformer)
+            sender.send(account_info).await?;
+
+            Ok(())
         })
     }
 }
 
 impl Clone for SnapshotHandle {
     fn clone(&self) -> Self {
-        Self(Arc::clone(&self.0))
+        Self(self.0.clone())
     }
 }
 
@@ -558,8 +560,10 @@ impl<H: MessageHandler> IngestStream<H> {
                                     Ok(()) => {
                                         program_transformer_task_status_inc(&config.name, &config.consumer, ProgramTransformerTaskStatusKind::Success);
                                     }
+                                    Err(IngestMessageError::SnapshotSend(e)) => {
+                                        program_transformer_task_status_inc(&config.name, &config.consumer, e.into());
+                                    }
                                     Err(IngestMessageError::RedisStreamMessage(e)) => {
-                                        error!("Failed to process message: {:?}", e);
                                         program_transformer_task_status_inc(&config.name, &config.consumer, e.into());
                                     }
                                     Err(IngestMessageError::DownloadMetadataJson(e)) => {

--- a/grpc-ingest/src/snapshot.rs
+++ b/grpc-ingest/src/snapshot.rs
@@ -3,15 +3,22 @@ use crate::{
     grpc,
     redis::{IngestStream, SnapshotHandle},
 };
+use anyhow::anyhow;
 use das_core::{DownloadMetadataJsonRetryConfig, MetadataJsonDownloadWorker};
 use digital_asset_types::dao::{account_snapshots, token_accounts, tokens};
 use futures::stream::StreamExt;
+use program_transformers::AccountInfo;
 use sea_orm::{
     sea_query::{Expr, PostgresQueryBuilder, Query},
     EntityTrait, JoinType, SqlxPostgresConnector,
 };
 use sea_orm::{ConnectionTrait, Statement};
-use tracing::{info, warn};
+use sqlx::PgPool;
+use tokio::{
+    sync::{mpsc, oneshot},
+    task::{JoinHandle, JoinSet},
+};
+use tracing::{error, info, warn};
 use {
     crate::{postgres::create_pool as pg_create_pool, util::create_shutdown},
     das_core::create_download_metadata_notifier,
@@ -20,6 +27,9 @@ use {
     std::sync::Arc,
     tokio::time::{sleep, Duration},
 };
+
+const DEFAULT_PROGRAM_TRANSFORMER_MAX_WORKERS: usize = 20;
+const DEFAULT_PROGRAM_TRANSFORMER_BUFFER_CAPACITY: usize = 10_000;
 
 pub async fn run(config: ConfigSnapshot) -> anyhow::Result<()> {
     let redis_client = redis::Client::open(config.redis.url.clone())?;
@@ -37,7 +47,6 @@ pub async fn run(config: ConfigSnapshot) -> anyhow::Result<()> {
         .retry(Arc::new(DownloadMetadataJsonRetryConfig::default()))
         .build()?
         .run();
-
     let download_metadata_notifier =
         create_download_metadata_notifier(download_metadata_sender).await;
 
@@ -45,11 +54,29 @@ pub async fn run(config: ConfigSnapshot) -> anyhow::Result<()> {
         pool.clone(),
         download_metadata_notifier,
     ));
+    let program_transformer_runner = ProgramTransformerRunner::builder()
+        .max_workers(config.program_transform.max_workers)
+        .buffer_capacity(config.program_transform.buffer_capacity)
+        .program_transformer(program_transformer)
+        .build()?;
+    let program_transformer_runner_sender = program_transformer_runner.sender();
+
+    let mut account_snapshot_writer = AccountSnapshotWriter::builder()
+        .pool(pool.clone())
+        .max_workers(config.snapshot_write.max_workers)
+        .batch_size(config.snapshot_write.batch_size)
+        .channel_capacity(config.snapshot_write.channel_capacity)
+        .program_transformer_runner_sender(program_transformer_runner_sender)
+        .build();
+    let account_snapshot_writer_sender = account_snapshot_writer.sender();
+    let mut account_snapshot_writer_error_receiver = account_snapshot_writer
+        .take_error_receiver()
+        .expect("Error receiver already taken");
 
     let account_snapshot_stream = IngestStream::build()
-        .config(config.snapshots.clone())
+        .config(config.snapshot_process.clone())
         .connection(connection.clone())
-        .handler(SnapshotHandle::new(Arc::clone(&program_transformer)))
+        .handler(SnapshotHandle::new(account_snapshot_writer_sender))
         .start()
         .await?;
 
@@ -57,6 +84,7 @@ pub async fn run(config: ConfigSnapshot) -> anyhow::Result<()> {
 
     let mut shutdown = create_shutdown()?;
     let mut connection = connection.clone();
+
     loop {
         tokio::select! {
             _ = shutdown.next() => {
@@ -64,22 +92,39 @@ pub async fn run(config: ConfigSnapshot) -> anyhow::Result<()> {
                     action = "shutdown_signal_received",
                     message = "Shutdown signal received, stopping ingest streams",
                 );
-                break;
+
+                return Ok(());
             }
 
-            Ok(len) = connection.xlen::<String, usize>(config.snapshots.name.clone()) => {
+            Ok(len) = connection.xlen::<String, usize>(config.snapshot_process.name.clone()) => {
                 if len == 0 {
                     break;
                 }
             }
 
+            _ = account_snapshot_writer_error_receiver.recv() => {
+                return Err(anyhow!("Failed to write a snapshot batch"))
+            }
+
             _ = sleep(Duration::from_millis(100)) => {}
         }
     }
+
     account_snapshot_stream.stop().await?;
+
+    account_snapshot_writer.shutdown().await;
+
+    program_transformer_runner.shutdown().await;
+
     download_metadata_worker.stop().await?;
 
     let db_connection = SqlxPostgresConnector::from_sqlx_postgres_pool(pool);
+
+    let slot = account_snapshots::Entity::find()
+        .one(&db_connection)
+        .await?
+        .map(|model| model.slot)
+        .ok_or(anyhow!("No snapshot slot"))?;
 
     let (sql, values) = Query::delete()
         .from_table(token_accounts::Entity)
@@ -98,6 +143,10 @@ pub async fn run(config: ConfigSnapshot) -> anyhow::Result<()> {
                     .and_where(
                         Expr::tbl(account_snapshots::Entity, account_snapshots::Column::Pubkey)
                             .is_null(),
+                    )
+                    .and_where(
+                        Expr::tbl(token_accounts::Entity, token_accounts::Column::SlotUpdated)
+                            .lte(slot),
                     )
                     .to_owned(),
             ),
@@ -135,6 +184,7 @@ pub async fn run(config: ConfigSnapshot) -> anyhow::Result<()> {
                         Expr::tbl(account_snapshots::Entity, account_snapshots::Column::Pubkey)
                             .is_null(),
                     )
+                    .and_where(Expr::tbl(tokens::Entity, tokens::Column::SlotUpdated).lte(slot))
                     .to_owned(),
             ),
         )
@@ -156,7 +206,275 @@ pub async fn run(config: ConfigSnapshot) -> anyhow::Result<()> {
         .await?;
 
     let mut con = connection.clone();
-    let _: () = con.del(config.snapshots.name.clone()).await?;
+    let _: () = con.del(config.snapshot_process.name.clone()).await?;
 
     Ok(())
+}
+
+pub struct AccountSnapshotWriter {
+    update_sender: mpsc::Sender<AccountInfo>,
+    stop_sender: Option<oneshot::Sender<()>>,
+    error_receiver: Option<mpsc::Receiver<()>>,
+    handle: tokio::task::JoinHandle<()>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct AccountSnapshotWriterBuilder {
+    channel_capacity: Option<usize>,
+    batch_size: Option<usize>,
+    pool: Option<PgPool>,
+    max_workers: Option<usize>,
+    program_transformer_runner_sender: Option<mpsc::Sender<Vec<AccountInfo>>>,
+}
+
+impl AccountSnapshotWriterBuilder {
+    pub const fn batch_size(mut self, batch_size: usize) -> Self {
+        self.batch_size = Some(batch_size);
+        self
+    }
+
+    pub const fn channel_capacity(mut self, channel_capacity: usize) -> Self {
+        self.channel_capacity = Some(channel_capacity);
+        self
+    }
+
+    pub fn pool(mut self, pool: PgPool) -> Self {
+        self.pool = Some(pool);
+        self
+    }
+
+    pub const fn max_workers(mut self, max_workers: usize) -> Self {
+        self.max_workers = Some(max_workers);
+        self
+    }
+
+    pub fn program_transformer_runner_sender(
+        mut self,
+        program_transformer_runner_sender: mpsc::Sender<Vec<AccountInfo>>,
+    ) -> Self {
+        self.program_transformer_runner_sender = Some(program_transformer_runner_sender);
+        self
+    }
+
+    pub fn build(self) -> AccountSnapshotWriter {
+        let channel_capacity = self.channel_capacity.expect("Channel capacity is required");
+        let batch_size = self.batch_size.expect("Batch size is required");
+        let pool = self.pool.expect("PgPool is required");
+        let max_workers = self.max_workers.expect("Max workers is required");
+        let program_transformer_runner_sender = self
+            .program_transformer_runner_sender
+            .expect("Program transformer runner sender is required");
+
+        let (update_sender, mut update_receiver) = mpsc::channel::<AccountInfo>(channel_capacity);
+        let (stop_sender, stop_receiver) = oneshot::channel::<()>();
+        let (error_sender, error_receiver) = mpsc::channel::<()>(max_workers);
+
+        let handle = tokio::spawn(async move {
+            let mut updates = Vec::new();
+            tokio::pin!(stop_receiver);
+            let error_sender = error_sender.clone();
+            let mut join_set = JoinSet::new();
+
+            loop {
+                tokio::select! {
+                    Some(update) = update_receiver.recv() => {
+                        updates.push(update);
+
+                        if updates.len() >= batch_size {
+                            let batch = std::mem::take(&mut updates);
+
+                            let conn = SqlxPostgresConnector::from_sqlx_postgres_pool(pool.clone());
+                            let accounts: Vec<account_snapshots::ActiveModel> = batch
+                                .clone()
+                                .iter()
+                                .map(|info| info.into_account_snapshot())
+                                .collect();
+
+                            while join_set.len() >= max_workers {
+                                join_set.join_next().await;
+                            }
+
+                            let error_sender = error_sender.clone();
+
+                            join_set.spawn(async move {
+                                if (account_snapshots::Entity::insert_many(accounts)
+                                    .exec(&conn)
+                                    .await).is_err()
+                                {
+                                    if let Err(e) = error_sender.send(()).await {
+                                        error!("Failed to send batch write error: {}", e);
+                                    }
+                                }
+                            });
+
+                            if let Err(e) = program_transformer_runner_sender.send(batch).await {
+                                error!("Failed program transformer sender: {}", e)
+                            }
+                        }
+                    }
+                    _ = &mut stop_receiver => {
+                        if !updates.is_empty() {
+                            let batch = std::mem::take(&mut updates);
+
+                            let conn = SqlxPostgresConnector::from_sqlx_postgres_pool(pool.clone());
+                            let accounts: Vec<account_snapshots::ActiveModel> = batch
+                                .clone()
+                                .iter()
+                                .map(|info| info.into_account_snapshot())
+                                .collect();
+
+                            while join_set.len() >= max_workers {
+                                join_set.join_next().await;
+                            }
+
+
+                            if (account_snapshots::Entity::insert_many(accounts)
+                                .exec(&conn)
+                                .await).is_err()
+                            {
+                                if let Err(e) = error_sender.send(()).await {
+                                    error!("Failed to send batch write error: {}", e);
+                                }
+                            }
+
+                            if let Err(e) = program_transformer_runner_sender.send(batch).await {
+                                error!("Failed program transformer sender: {}", e)
+                            }
+                        }
+                        break;
+                    }
+                }
+            }
+
+            while (join_set.join_next().await).is_some() {}
+        });
+
+        AccountSnapshotWriter {
+            update_sender,
+            stop_sender: Some(stop_sender),
+            error_receiver: Some(error_receiver),
+            handle,
+        }
+    }
+}
+
+impl AccountSnapshotWriter {
+    pub fn builder() -> AccountSnapshotWriterBuilder {
+        AccountSnapshotWriterBuilder::default()
+    }
+
+    pub fn sender(&self) -> mpsc::Sender<AccountInfo> {
+        self.update_sender.clone()
+    }
+
+    pub fn take_error_receiver(&mut self) -> Option<mpsc::Receiver<()>> {
+        self.error_receiver.take()
+    }
+
+    pub async fn shutdown(mut self) {
+        if let Some(stop_sender) = self.stop_sender.take() {
+            let _ = stop_sender.send(());
+        }
+
+        let _ = self.handle.await;
+    }
+}
+
+pub struct ProgramTransformerRunner {
+    handle: JoinHandle<()>,
+    worker_sender: mpsc::Sender<Vec<AccountInfo>>,
+    shutdown_sender: Option<oneshot::Sender<()>>,
+}
+
+impl ProgramTransformerRunner {
+    pub fn builder() -> ProgramTransformerRunnerBuilder {
+        ProgramTransformerRunnerBuilder::default()
+    }
+
+    pub fn sender(&self) -> mpsc::Sender<Vec<AccountInfo>> {
+        self.worker_sender.clone()
+    }
+
+    pub async fn shutdown(mut self) {
+        if let Some(shutdown_sender) = self.shutdown_sender.take() {
+            let _ = shutdown_sender.send(());
+        }
+
+        let _ = self.handle.await;
+    }
+}
+
+#[derive(Default)]
+pub struct ProgramTransformerRunnerBuilder {
+    max_workers: Option<usize>,
+    buffer_capacity: Option<usize>,
+    program_transformer: Option<Arc<ProgramTransformer>>,
+}
+
+impl ProgramTransformerRunnerBuilder {
+    pub const fn max_workers(mut self, max_workers: usize) -> Self {
+        self.max_workers = Some(max_workers);
+        self
+    }
+
+    pub const fn buffer_capacity(mut self, buffer_capacity: usize) -> Self {
+        self.buffer_capacity = Some(buffer_capacity);
+        self
+    }
+
+    pub fn program_transformer(mut self, program_transformer: Arc<ProgramTransformer>) -> Self {
+        self.program_transformer = Some(program_transformer);
+        self
+    }
+
+    pub fn build(self) -> Result<ProgramTransformerRunner, anyhow::Error> {
+        let buffer_capacity = self
+            .buffer_capacity
+            .unwrap_or(DEFAULT_PROGRAM_TRANSFORMER_BUFFER_CAPACITY);
+        let (worker_sender, mut worker_receiver) =
+            mpsc::channel::<Vec<AccountInfo>>(buffer_capacity);
+        let (shutdown_sender, mut shutdown_receiver) = oneshot::channel();
+        let program_transformer = self
+            .program_transformer
+            .expect("Program transform to be set");
+
+        let max_workers = self
+            .max_workers
+            .unwrap_or(DEFAULT_PROGRAM_TRANSFORMER_MAX_WORKERS);
+
+        let handle = tokio::spawn(async move {
+            let mut join_set = JoinSet::new();
+
+            loop {
+                tokio::select! {
+                    _ = &mut shutdown_receiver => {
+                        break;
+                    }
+                    Some(account_infos) = worker_receiver.recv() => {
+                        let program_transformer = Arc::clone(&program_transformer);
+
+                        for account_info in account_infos {
+                            while join_set.len() >= max_workers {
+                                join_set.join_next().await;
+                            }
+
+                            let program_transformer = Arc::clone(&program_transformer);
+
+                            join_set.spawn(async move {
+                                let _ = program_transformer.handle_account_update(&account_info).await;
+                            });
+                        }
+                    }
+                }
+            }
+
+            while (join_set.join_next().await).is_some() {}
+        });
+
+        Ok(ProgramTransformerRunner {
+            handle,
+            worker_sender,
+            shutdown_sender: Some(shutdown_sender),
+        })
+    }
 }

--- a/program_transformers/src/lib.rs
+++ b/program_transformers/src/lib.rs
@@ -24,8 +24,9 @@ use {
     das_core::{DownloadMetadataInfo, DownloadMetadataNotifier},
     digital_asset_types::dao::{account_snapshots, asset, slot_metas, token_accounts, tokens},
     sea_orm::{
-        entity::EntityTrait, query::Select, sea_query::Expr, ColumnTrait, ConnectionTrait,
-        DatabaseConnection, DbErr, QueryFilter, Set, SqlxPostgresConnector, TransactionTrait,
+        entity::EntityTrait, query::Select, sea_query::Expr, ActiveValue, ColumnTrait,
+        ConnectionTrait, DatabaseConnection, DbErr, QueryFilter, Set, SqlxPostgresConnector,
+        TransactionTrait,
     },
     serde::Deserialize,
     serde_json::{Map, Value},
@@ -55,6 +56,16 @@ pub struct AccountInfo {
     pub pubkey: Pubkey,
     pub owner: Pubkey,
     pub data: Vec<u8>,
+}
+
+impl AccountInfo {
+    pub fn into_account_snapshot(&self) -> account_snapshots::ActiveModel {
+        account_snapshots::ActiveModel {
+            pubkey: ActiveValue::Set(self.pubkey.to_bytes().to_vec()),
+            slot: ActiveValue::Set(self.slot as i64),
+            owner: ActiveValue::Set(self.owner.to_bytes().to_vec()),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
@@ -274,27 +285,6 @@ impl ProgramTransformer {
             .filter(slot_metas::Column::Slot.lt(slot))
             .exec(&db)
             .await?;
-
-        Ok(())
-    }
-
-    pub async fn handle_account_snapshot_update(
-        &self,
-        account_info: &AccountInfo,
-    ) -> ProgramTransformerResult<()> {
-        let conn = SqlxPostgresConnector::from_sqlx_postgres_pool(self.storage.clone());
-
-        let account_snapshot = account_snapshots::ActiveModel {
-            pubkey: sea_orm::ActiveValue::Set(account_info.pubkey.to_bytes().to_vec()),
-            slot: sea_orm::ActiveValue::Set(account_info.slot as i64),
-            owner: sea_orm::ActiveValue::Set(account_info.owner.to_bytes().to_vec()),
-        };
-
-        account_snapshots::Entity::insert(account_snapshot)
-            .exec(&conn)
-            .await?;
-
-        self.handle_account_update(account_info).await?;
 
         Ok(())
     }


### PR DESCRIPTION
## Changes
- Instead of writing one account snapshot record at a time batch the insertions
- Run account snapshot writing and program transformers on separate worker queues