### PR TITLE
Add fenced subquery on getAssetsByGroup so it uses the correct index

### DIFF
--- a/core/src/db.rs
+++ b/core/src/db.rs
@@ -75,7 +75,10 @@ impl PoolArgs {
 /////
 ///// * `Result<PgPool, sqlx::Error>` - On success, returns a `PgPool`. On failure, returns a `sqlx::Error`.
 pub async fn connect_db(config: &PoolArgs) -> Result<PgPool, sqlx::Error> {
-    let options: PgConnectOptions = config.database_url.parse()?;
+    let options: PgConnectOptions = config
+        .database_url
+        .parse::<PgConnectOptions>()?
+        .options([("statement_timeout", "10000")]);
 
     PgPoolOptions::new()
         .min_connections(config.database_min_connections)

--- a/digital_asset_types/src/dao/scopes/asset.rs
+++ b/digital_asset_types/src/dao/scopes/asset.rs
@@ -13,7 +13,7 @@ use indexmap::IndexMap;
 use sea_orm::{
     prelude::Decimal,
     sea_query::{
-        Condition, ConditionType, Expr, PostgresQueryBuilder, Query, SimpleExpr, UnionType,
+        Alias, Condition, ConditionType, Expr, PostgresQueryBuilder, Query, SimpleExpr, UnionType,
     },
     ActiveEnum, ColumnTrait, ConnectionTrait, DbErr, EntityTrait, FromQueryResult, JoinType, Order,
     QueryFilter, QueryOrder, Statement,
@@ -242,23 +242,30 @@ where
             )),
             extensions::asset::Column::TokenAccountDelegatedAmount,
         )
-        .join(
+        // Fenced subquery: works around the Postgres ORDER BY + LIMIT planner trap that picks the wrong index on `asset_grouping` and scans
+        // hundreds of millions of rows. `OFFSET 0` is the optimization fence. https://www.endpointdev.com/blog/2009/04/offset-0-ftw/
+        // pg doesnt know the best query to use lol
+        .join_subquery(
             JoinType::InnerJoin,
-            asset_grouping::Entity,
-            Condition::all()
-                .add(
-                    asset_grouping::Column::GroupKey.eq(group_key).and(
-                        asset_grouping::Column::GroupValue.eq(group_value).and(
-                            Expr::tbl(extensions::asset::Entity, asset::Column::Id)
-                                .equals(asset_grouping::Entity, asset_grouping::Column::AssetId),
-                        ),
-                    ),
+            Query::select()
+                .column(asset_grouping::Column::AssetId)
+                .from(asset_grouping::Entity)
+                .cond_where(
+                    Condition::all()
+                        .add(asset_grouping::Column::GroupKey.eq(group_key))
+                        .add(asset_grouping::Column::GroupValue.eq(group_value))
+                        .add(asset_grouping::Column::GroupValue.is_not_null())
+                        .add_option((!options.show_unverified_collections).then(|| {
+                            asset_grouping::Column::Verified
+                                .eq(true)
+                                .or(asset_grouping::Column::Verified.is_null())
+                        })),
                 )
-                .add_option((!options.show_unverified_collections).then(|| {
-                    asset_grouping::Column::Verified
-                        .eq(true)
-                        .or(asset_grouping::Column::Verified.is_null())
-                })),
+                .offset(0u64)
+                .take(),
+            Alias::new("ag"),
+            Expr::tbl(Alias::new("ag"), asset_grouping::Column::AssetId)
+                .equals(extensions::asset::Entity, asset::Column::Id),
         )
         .join(
             JoinType::LeftJoin,


### PR DESCRIPTION
pg was inferring the index to use in the getAssetByGroups query, similar issue for reference: http://datamangling.com/2014/01/17/limit-1-and-performance-in-a-postgres-query/
