### PR TITLE
ci: migrate to goreleaser Gen 2 (PLA-454)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,83 @@
+# .goreleaser.yaml for rpcpool/digital-asset-rpc-infrastructure
+#
+# This file must be committed to the root of the source repo.
+# GCS upload, cosigning, and GitHub Release publishing are injected via
+# ci/goreleaser-patch.yaml in Binaries-ci at build time.
+#
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+
+version: 2
+
+builds:
+    - id: das-api
+      builder: rust
+      binary: das_api
+      targets:
+          - x86_64-unknown-linux-gnu
+      flags:
+          - --release
+          - --bin=das_api
+
+    - id: migration
+      builder: rust
+      binary: migration
+      targets:
+          - x86_64-unknown-linux-gnu
+      flags:
+          - --release
+          - --bin=migration
+
+    - id: das-ops
+      builder: rust
+      binary: das-ops
+      targets:
+          - x86_64-unknown-linux-gnu
+      flags:
+          - --release
+          - --bin=das-ops
+
+    # nft_ingester is the cargo binary name; the archive renames it to
+    # das-grpc-ingest-linux-amd64 to preserve the name used by Nomad jobs.
+    - id: das-grpc-ingest
+      builder: rust
+      binary: nft_ingester
+      targets:
+          - x86_64-unknown-linux-gnu
+      flags:
+          - --release
+          - --bin=nft_ingester
+
+archives:
+    - id: das-api
+      ids: [das-api]
+      name_template: das_api-linux-amd64
+      formats: [binary]
+
+    - id: migration
+      ids: [migration]
+      name_template: migration-linux-amd64
+      formats: [binary]
+
+    - id: das-ops
+      ids: [das-ops]
+      name_template: das-ops-linux-amd64
+      formats: [binary]
+
+    - id: das-grpc-ingest
+      ids: [das-grpc-ingest]
+      name_template: das-grpc-ingest-linux-amd64
+      formats: [binary]
+
+release:
+    github:
+        owner: rpcpool
+        name: digital-asset-rpc-infrastructure
+    draft: true
+    header: |
+        rust {{ .Env.RUST_VERSION }}
+    extra_files:
+        - glob: init.sql
+
+changelog:
+    sort: asc
+    use: github

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,10 +4,10 @@
 # GCS upload, cosigning, and GitHub Release publishing are injected via
 # ci/goreleaser-patch.yaml in Binaries-ci at build time.
 #
-# All four workspace binaries are built in a single cargo invocation via
-# before.hooks to avoid parallel cargo file-lock contention. Each build
-# entry re-runs cargo with --offline so it is a no-op (binary already
-# present) without needing the network registry lock.
+# All four workspace binaries are built in a single cargo zigbuild invocation
+# via before.hooks (matching the toolchain goreleaser's rust builder uses).
+# Each build entry then uses tool:/bin/true so goreleaser skips cargo entirely
+# and picks up the already-compiled binaries from the target directory.
 #
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 
@@ -15,50 +15,38 @@ version: 2
 
 before:
     hooks:
-        - cargo build --release --target x86_64-unknown-linux-gnu --package=das_api --package=migration --package=das-ops --package=nft_ingester
+        - cargo zigbuild --release --target x86_64-unknown-linux-gnu --package=das_api --package=migration --package=das-ops --package=nft_ingester
 
 builds:
     - id: das-api
       builder: rust
+      tool: /bin/true
       binary: das_api
       targets:
           - x86_64-unknown-linux-gnu
-      flags:
-          - --release
-          - --package=das_api
-          - --offline
 
     - id: migration
       builder: rust
+      tool: /bin/true
       binary: migration
       targets:
           - x86_64-unknown-linux-gnu
-      flags:
-          - --release
-          - --package=migration
-          - --offline
 
     - id: das-ops
       builder: rust
+      tool: /bin/true
       binary: das-ops
       targets:
           - x86_64-unknown-linux-gnu
-      flags:
-          - --release
-          - --package=das-ops
-          - --offline
 
     # nft_ingester is the cargo binary name; the archive renames it to
     # das-grpc-ingest-linux-amd64 to preserve the name used by Nomad jobs.
     - id: das-grpc-ingest
       builder: rust
+      tool: /bin/true
       binary: nft_ingester
       targets:
           - x86_64-unknown-linux-gnu
-      flags:
-          - --release
-          - --package=nft_ingester
-          - --offline
 
 archives:
     - id: das-api

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,48 +4,52 @@
 # GCS upload, cosigning, and GitHub Release publishing are injected via
 # ci/goreleaser-patch.yaml in Binaries-ci at build time.
 #
+# All four workspace binaries are built in a single cargo invocation via
+# before.hooks to avoid parallel cargo file-lock contention. Each build
+# entry then picks up its pre-built binary via builder: prebuilt.
+#
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 
 version: 2
 
+before:
+    hooks:
+        - cargo build --release --target x86_64-unknown-linux-gnu --package=das_api --package=migration --package=das-ops --package=nft_ingester
+
 builds:
     - id: das-api
-      builder: rust
+      builder: prebuilt
+      goos: [linux]
+      goarch: [amd64]
       binary: das_api
-      targets:
-          - x86_64-unknown-linux-gnu
-      flags:
-          - --release
-          - --package=das_api
+      prebuilt:
+          path: target/x86_64-unknown-linux-gnu/release/das_api
 
     - id: migration
-      builder: rust
+      builder: prebuilt
+      goos: [linux]
+      goarch: [amd64]
       binary: migration
-      targets:
-          - x86_64-unknown-linux-gnu
-      flags:
-          - --release
-          - --package=migration
+      prebuilt:
+          path: target/x86_64-unknown-linux-gnu/release/migration
 
     - id: das-ops
-      builder: rust
+      builder: prebuilt
+      goos: [linux]
+      goarch: [amd64]
       binary: das-ops
-      targets:
-          - x86_64-unknown-linux-gnu
-      flags:
-          - --release
-          - --package=das-ops
+      prebuilt:
+          path: target/x86_64-unknown-linux-gnu/release/das-ops
 
     # nft_ingester is the cargo binary name; the archive renames it to
     # das-grpc-ingest-linux-amd64 to preserve the name used by Nomad jobs.
     - id: das-grpc-ingest
-      builder: rust
-      binary: nft_ingester
-      targets:
-          - x86_64-unknown-linux-gnu
-      flags:
-          - --release
-          - --package=nft_ingester
+      builder: prebuilt
+      goos: [linux]
+      goarch: [amd64]
+      binary: das-grpc-ingest
+      prebuilt:
+          path: target/x86_64-unknown-linux-gnu/release/nft_ingester
 
 archives:
     - id: das-api

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -15,7 +15,7 @@ version: 2
 
 before:
     hooks:
-        - cargo zigbuild --release --target x86_64-unknown-linux-gnu --package=das_api --package=migration --package=das-ops --package=nft_ingester
+        - cargo build --release --target x86_64-unknown-linux-gnu --package=das_api --package=migration --package=das-ops --package=nft_ingester
 
 builds:
     - id: das-api

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,6 +24,8 @@ builds:
       binary: das_api
       targets:
           - x86_64-unknown-linux-gnu
+      flags:
+          - --package=das_api
 
     - id: migration
       builder: rust
@@ -31,6 +33,8 @@ builds:
       binary: migration
       targets:
           - x86_64-unknown-linux-gnu
+      flags:
+          - --package=migration
 
     - id: das-ops
       builder: rust
@@ -38,6 +42,8 @@ builds:
       binary: das-ops
       targets:
           - x86_64-unknown-linux-gnu
+      flags:
+          - --package=das-ops
 
     # nft_ingester is the cargo binary name; the archive renames it to
     # das-grpc-ingest-linux-amd64 to preserve the name used by Nomad jobs.
@@ -47,6 +53,8 @@ builds:
       binary: nft_ingester
       targets:
           - x86_64-unknown-linux-gnu
+      flags:
+          - --package=nft_ingester
 
 archives:
     - id: das-api

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,7 +16,7 @@ builds:
           - x86_64-unknown-linux-gnu
       flags:
           - --release
-          - --bin=das_api
+          - --package=das_api
 
     - id: migration
       builder: rust
@@ -25,7 +25,7 @@ builds:
           - x86_64-unknown-linux-gnu
       flags:
           - --release
-          - --bin=migration
+          - --package=migration
 
     - id: das-ops
       builder: rust
@@ -34,7 +34,7 @@ builds:
           - x86_64-unknown-linux-gnu
       flags:
           - --release
-          - --bin=das-ops
+          - --package=das-ops
 
     # nft_ingester is the cargo binary name; the archive renames it to
     # das-grpc-ingest-linux-amd64 to preserve the name used by Nomad jobs.
@@ -45,7 +45,7 @@ builds:
           - x86_64-unknown-linux-gnu
       flags:
           - --release
-          - --bin=nft_ingester
+          - --package=nft_ingester
 
 archives:
     - id: das-api

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -6,7 +6,8 @@
 #
 # All four workspace binaries are built in a single cargo invocation via
 # before.hooks to avoid parallel cargo file-lock contention. Each build
-# entry then picks up its pre-built binary via builder: prebuilt.
+# entry re-runs cargo with --offline so it is a no-op (binary already
+# present) without needing the network registry lock.
 #
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 
@@ -18,38 +19,46 @@ before:
 
 builds:
     - id: das-api
-      builder: prebuilt
-      goos: [linux]
-      goarch: [amd64]
+      builder: rust
       binary: das_api
-      prebuilt:
-          path: target/x86_64-unknown-linux-gnu/release/das_api
+      targets:
+          - x86_64-unknown-linux-gnu
+      flags:
+          - --release
+          - --package=das_api
+          - --offline
 
     - id: migration
-      builder: prebuilt
-      goos: [linux]
-      goarch: [amd64]
+      builder: rust
       binary: migration
-      prebuilt:
-          path: target/x86_64-unknown-linux-gnu/release/migration
+      targets:
+          - x86_64-unknown-linux-gnu
+      flags:
+          - --release
+          - --package=migration
+          - --offline
 
     - id: das-ops
-      builder: prebuilt
-      goos: [linux]
-      goarch: [amd64]
+      builder: rust
       binary: das-ops
-      prebuilt:
-          path: target/x86_64-unknown-linux-gnu/release/das-ops
+      targets:
+          - x86_64-unknown-linux-gnu
+      flags:
+          - --release
+          - --package=das-ops
+          - --offline
 
     # nft_ingester is the cargo binary name; the archive renames it to
     # das-grpc-ingest-linux-amd64 to preserve the name used by Nomad jobs.
     - id: das-grpc-ingest
-      builder: prebuilt
-      goos: [linux]
-      goarch: [amd64]
-      binary: das-grpc-ingest
-      prebuilt:
-          path: target/x86_64-unknown-linux-gnu/release/nft_ingester
+      builder: rust
+      binary: nft_ingester
+      targets:
+          - x86_64-unknown-linux-gnu
+      flags:
+          - --release
+          - --package=nft_ingester
+          - --offline
 
 archives:
     - id: das-api


### PR DESCRIPTION
## Summary

- Adds `.goreleaser.yaml` to enable Gen 2 builds via `build-release.yml`
- Removes the need for a bespoke workflow in Binaries-ci
- All four workspace binaries built and uploaded to GCS at `digital-asset-rpc-infrastructure/{version}/`

## Build strategy

This is a multi-binary Rust workspace. goreleaser v2 runs build entries in parallel, which causes cargo file-lock contention when building 4 packages simultaneously. The solution:

1. `before.hooks` runs a single `cargo build --release` for all 4 packages (no parallelism, no lock contention)
2. Each goreleaser build entry uses `tool: /bin/true` to skip re-running cargo and just picks up the pre-built binary from `target/x86_64-unknown-linux-gnu/release/`
3. `--package=` flags are still required in each build entry to satisfy goreleaser's workspace pre-flight validation

The `nft_ingester` binary is archived as `das-grpc-ingest-linux-amd64` via `name_template` in the archives section to preserve the name used by Nomad jobs.

## Test plan

- [x] Build validated with test tag `v0.7.2-pla454.1` on Binaries-ci run [25425586060](https://github.com/rpcpool/Binaries-ci/actions/runs/25425586060)
- [x] All four binaries archived: `das_api-linux-amd64`, `migration-linux-amd64`, `das-ops-linux-amd64`, `das-grpc-ingest-linux-amd64`
- [x] GCS uploads confirmed at `digital-asset-rpc-infrastructure/v0.7.2-pla454.1/`
- [x] `init.sql` included as release extra file
- [x] cosign sigstore bundles generated for all artifacts
- [x] GitHub draft release created, Slack notification posted

🤖 Generated with [Claude Code](https://claude.com/claude-code)