### PR TITLE
ci: migrate to goreleaser Gen 2 (PLA-453)

### DIFF
--- a/.github/workflows/goreleaser-config-check.yaml
+++ b/.github/workflows/goreleaser-config-check.yaml
@@ -1,0 +1,26 @@
+---
+name: GoReleaser config check
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    paths:
+      - .goreleaser.yaml
+  workflow_dispatch:
+
+jobs:
+  goreleaser-check:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          install-only: true
+
+      - name: goreleaser check
+        run: goreleaser check

--- a/.github/workflows/goreleaser-config-check.yaml
+++ b/.github/workflows/goreleaser-config-check.yaml
@@ -14,11 +14,11 @@ jobs:
   goreleaser-check:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           fetch-depth: 1
 
-      - uses: goreleaser/goreleaser-action@v6
+      - uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a
         with:
           install-only: true
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,88 @@
+# .goreleaser.yaml for rpcpool/digital-asset-rpc-infrastructure
+#
+# This file must be committed to the root of the digital-asset-rpc-infrastructure source
+# repo. GCS upload, cosigning, and GitHub Release publishing are injected via
+# ci/goreleaser-patch.yaml in Binaries-ci at build time.
+#
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+
+version: 2
+
+before:
+  hooks:
+    - sh -c "git rev-parse --short HEAD > short-commit-hash.txt"
+
+builds:
+  - id: das_api
+    builder: rust
+    binary: das_api
+    targets:
+      - x86_64-unknown-linux-gnu
+    flags:
+      - --release
+      - --bin=das_api
+    env:
+      - OPENSSL_INCLUDE_DIR=/usr/include
+      - OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu
+
+  - id: migration
+    builder: rust
+    binary: migration
+    targets:
+      - x86_64-unknown-linux-gnu
+    flags:
+      - --release
+      - --bin=migration
+    env:
+      - OPENSSL_INCLUDE_DIR=/usr/include
+      - OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu
+
+  - id: das-ops
+    builder: rust
+    binary: das-ops
+    targets:
+      - x86_64-unknown-linux-gnu
+    flags:
+      - --release
+      - --bin=das-ops
+    env:
+      - OPENSSL_INCLUDE_DIR=/usr/include
+      - OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu
+
+  - id: nft_ingester
+    builder: rust
+    binary: nft_ingester
+    targets:
+      - x86_64-unknown-linux-gnu
+    flags:
+      - --release
+      - --bin=nft_ingester
+    env:
+      - OPENSSL_INCLUDE_DIR=/usr/include
+      - OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu
+
+archives:
+  - formats: [binary]
+    name_template: >-
+      {{ .Binary }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+
+extra_files:
+  - glob: init.sql
+  - glob: short-commit-hash.txt
+
+release:
+  github:
+    owner: rpcpool
+    name: digital-asset-rpc-infrastructure
+  draft: true
+  header: |
+    rust {{ .Env.RUST_VERSION }}
+
+changelog:
+  sort: asc
+  use: github

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -4,6 +4,11 @@
 # repo. GCS upload, cosigning, and GitHub Release publishing are injected via
 # ci/goreleaser-patch.yaml in Binaries-ci at build time.
 #
+# All four workspace binaries are built in a single cargo build invocation
+# via before.hooks (avoids cargo file-lock contention from parallel builds).
+# Each build entry then uses tool:/bin/true so goreleaser skips cargo entirely
+# and picks up the already-compiled binaries from the target directory.
+#
 # yaml-language-server: $schema=https://goreleaser.com/static/schema.json
 
 version: 2
@@ -11,55 +16,44 @@ version: 2
 before:
   hooks:
     - sh -c "git rev-parse --short HEAD > short-commit-hash.txt"
+    - cargo build --release --target x86_64-unknown-linux-gnu --package=das_api --package=migration --package=das-ops --package=nft_ingester
 
 builds:
   - id: das_api
     builder: rust
+    tool: /bin/true
     binary: das_api
     targets:
       - x86_64-unknown-linux-gnu
     flags:
-      - --release
-      - --bin=das_api
-    env:
-      - OPENSSL_INCLUDE_DIR=/usr/include
-      - OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu
+      - --package=das_api
 
   - id: migration
     builder: rust
+    tool: /bin/true
     binary: migration
     targets:
       - x86_64-unknown-linux-gnu
     flags:
-      - --release
-      - --bin=migration
-    env:
-      - OPENSSL_INCLUDE_DIR=/usr/include
-      - OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu
+      - --package=migration
 
   - id: das-ops
     builder: rust
+    tool: /bin/true
     binary: das-ops
     targets:
       - x86_64-unknown-linux-gnu
     flags:
-      - --release
-      - --bin=das-ops
-    env:
-      - OPENSSL_INCLUDE_DIR=/usr/include
-      - OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu
+      - --package=das-ops
 
   - id: nft_ingester
     builder: rust
+    tool: /bin/true
     binary: nft_ingester
     targets:
       - x86_64-unknown-linux-gnu
     flags:
-      - --release
-      - --bin=nft_ingester
-    env:
-      - OPENSSL_INCLUDE_DIR=/usr/include
-      - OPENSSL_LIB_DIR=/usr/lib/x86_64-linux-gnu
+      - --package=nft_ingester
 
 archives:
   - formats: [binary]

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -64,10 +64,9 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
-
-extra_files:
-  - glob: init.sql
-  - glob: short-commit-hash.txt
+    files:
+      - init.sql
+      - short-commit-hash.txt
 
 release:
   github:


### PR DESCRIPTION
## Summary

- Add `.goreleaser.yaml` with four explicit builds (`das_api`, `migration`, `das-ops`, `nft_ingester`) targeting `x86_64-unknown-linux-gnu`
- All four packages are pre-built in a single `cargo build` call in `before.hooks` to avoid cargo package-cache lock contention from goreleaser's parallel build phase
- Each build entry uses `tool: /bin/true` so goreleaser skips cargo and picks up the pre-built binary from `target/x86_64-unknown-linux-gnu/release/`
- `--package=<name>` flags on each build entry satisfy goreleaser's workspace pre-flight validator (required even when `tool` is overridden)
- Archive naming follows `{{ .Binary }}_Linux_x86_64` convention (e.g. `das_api_Linux_x86_64`)
- Bundle `init.sql` and `short-commit-hash.txt` as `extra_files` so they upload alongside binaries
- Add `.github/workflows/goreleaser-config-check.yaml` to validate config on PRs (GitHub-hosted runners — public repo)

**Note on parallel build deadlocks:** goreleaser runs rust build entries in parallel; for Cargo workspace projects, each parallel process tries to acquire the same package cache lock, causing timeouts. The `before.hooks` + `tool:/bin/true` pattern is required for all multi-binary workspace builds.

**Build validated:** Binaries-ci run `25425586060` built all four binaries, cosign-signed them, and uploaded to GCS at `digital-asset-rpc-infrastructure/v0.7.2-pla454.1/`.

Part of PLA-412 / PLA-453: migrating digital-asset-rpc-infrastructure to Binaries-ci Gen 2 goreleaser workflow.

**Companion PRs:**
- [Binaries-ci #2363](https://github.com/rpcpool/Binaries-ci/pull/2363): removes `solana_metaplex-das-build-release.yml` and ref file
- [terraform #845](https://github.com/rpcpool/terraform/pull/845): updates Nomad job GCS artifact paths
- [rpcpool #18915](https://github.com/rpcpool/rpcpool/pull/18915): updates Ansible role artifact names

**Merge order:** Merge this PR first (enables goreleaser check CI), then the Binaries-ci PR (removes old workflow), then terraform + rpcpool PRs before the first Gen 2 build is deployed.

## Test plan

- [x] Verify `goreleaser check` passes in the goreleaser-config-check workflow on this PR
- [x] After merge, trigger `build-release.yml` in Binaries-ci with `repo=digital-asset-rpc-infrastructure` and a semver tag
- [ ] Confirm all four binaries + `init.sql` + `short-commit-hash.txt` appear in the GCS bucket under `nomad-triton-test/digital-asset-rpc-infrastructure/v<semver>/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)